### PR TITLE
Remove Joda and replace it with Java 8 time classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,8 @@
         <version>3.2</version>
         <configuration>
           <!-- Target Java versions -->
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
     </plugins>
@@ -61,12 +61,6 @@
       <groupId>net.sourceforge.javacsv</groupId>
       <artifactId>javacsv</artifactId>
       <version>2.0</version>
-    </dependency>
-    <!-- Joda Time is a widely used replacement for flaky Java time classes. -->
-    <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-      <version>2.1</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/com/conveyal/gtfs/model/CalendarDate.java
+++ b/src/main/java/com/conveyal/gtfs/model/CalendarDate.java
@@ -17,7 +17,7 @@ import com.conveyal.gtfs.GTFSFeed;
 import com.conveyal.gtfs.error.DuplicateKeyError;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterators;
-import org.joda.time.LocalDate;
+import java.time.LocalDate;
 
 import java.io.IOException;
 import java.io.Serializable;

--- a/src/main/java/com/conveyal/gtfs/model/Entity.java
+++ b/src/main/java/com/conveyal/gtfs/model/Entity.java
@@ -16,9 +16,6 @@ import com.csvreader.CsvReader;
 import com.csvreader.CsvWriter;
 
 import org.apache.commons.io.input.BOMInputStream;
-import org.joda.time.LocalDate;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,6 +27,8 @@ import java.io.Serializable;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map;
@@ -157,14 +156,13 @@ public abstract class Entity implements Serializable {
 
         /**
          * Fetch the given column of the current row, and interpret it as a date in the format YYYYMMDD.
-         * @return the date value as Joda LocalDate, or null if it could not be parsed.
+         * @return the date value as Java LocalDate, or null if it could not be parsed.
          */
         protected LocalDate getDateField(String column, boolean required) throws IOException {
             String str = getFieldCheckRequired(column, required);
             LocalDate dateTime = null;
             if (str != null) try {
-                DateTimeFormatter formatter = DateTimeFormat.forPattern("yyyyMMdd");
-                dateTime = formatter.parseLocalDate(str);
+                dateTime = LocalDate.parse(str, DateTimeFormatter.BASIC_ISO_DATE);
                 checkRangeInclusive(2000, 2100, dateTime.getYear());
             } catch (IllegalArgumentException iae) {
                 feed.errors.add(new DateParseError(tableName, row, column));
@@ -357,8 +355,11 @@ public abstract class Entity implements Serializable {
             writeStringField(obj != null ? obj.toString() : "");
         }
 
+        /**
+         * Writes date as YYYYMMDD
+         */
         protected void writeDateField (LocalDate d) throws IOException {
-            writeStringField(String.format("%04d%02d%02d", d.getYear(), d.getMonthOfYear(), d.getDayOfMonth()));
+            writeStringField(d.format(DateTimeFormatter.BASIC_ISO_DATE));
         }
 
         /**

--- a/src/main/java/com/conveyal/gtfs/model/Fare.java
+++ b/src/main/java/com/conveyal/gtfs/model/Fare.java
@@ -2,7 +2,6 @@ package com.conveyal.gtfs.model;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import org.joda.time.DateTime;
 
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/com/conveyal/gtfs/model/FeedInfo.java
+++ b/src/main/java/com/conveyal/gtfs/model/FeedInfo.java
@@ -16,8 +16,7 @@ package com.conveyal.gtfs.model;
 import com.conveyal.gtfs.GTFSFeed;
 import com.conveyal.gtfs.error.GeneralError;
 
-import org.joda.time.DateTime;
-import org.joda.time.LocalDate;
+import java.time.LocalDate;
 
 import java.io.IOException;
 import java.net.URL;

--- a/src/main/java/com/conveyal/gtfs/model/Service.java
+++ b/src/main/java/com/conveyal/gtfs/model/Service.java
@@ -1,7 +1,7 @@
 package com.conveyal.gtfs.model;
 
 import com.google.common.collect.Maps;
-import org.joda.time.LocalDate;
+import java.time.LocalDate;
 
 import java.io.Serializable;
 import java.util.Map;
@@ -37,7 +37,7 @@ public class Service implements Serializable {
             return false;
 
         else {
-            int gtfsDate = date.getYear() * 10000 + date.getMonthOfYear() * 100 + date.getDayOfMonth(); 
+            int gtfsDate = date.getYear() * 10000 + date.getMonthValue() * 100 + date.getDayOfMonth();
             return calendar.end_date >= gtfsDate && calendar.start_date <= gtfsDate;
         }
     }


### PR DESCRIPTION
This fully removes Joda from gtfs-lib and makes it java 8 library since it needs java 8 date and time classes.

I removed Joda because I removed it also in r5: conveyal/r5#10.
When this is merged r5 also needs to be updated.