### PR TITLE
Add empty table error, pretty print json validation

### DIFF
--- a/src/main/java/com/conveyal/gtfs/GTFSMain.java
+++ b/src/main/java/com/conveyal/gtfs/GTFSMain.java
@@ -44,7 +44,7 @@ public class GTFSMain {
             feed.validate();
             JsonManager<ValidationResult> json = new JsonManager(ValidationResult.class);
             ValidationResult result = new ValidationResult(arguments[0], feed, new FeedStats(feed));
-            String resultString = json.write(result);
+            String resultString = json.writePretty(result);
             File resultFile;
             if (arguments.length >= 2) {
                 resultFile = new File(arguments[1]);
@@ -52,6 +52,7 @@ public class GTFSMain {
                 LOG.info("Storing validation result at: {}", resultFile.getAbsolutePath());
             } else {
                 LOG.info("Printing validation result for {}", feed.feedId);
+
                 System.out.print(resultString);
             }
         }

--- a/src/main/java/com/conveyal/gtfs/error/EmptyTableError.java
+++ b/src/main/java/com/conveyal/gtfs/error/EmptyTableError.java
@@ -1,0 +1,18 @@
+package com.conveyal.gtfs.error;
+
+import java.io.Serializable;
+
+/**
+ * Created by landon on 4/5/17.
+ */
+public class EmptyTableError extends GTFSError implements Serializable {
+    public static final long serialVersionUID = 1L;
+
+    public EmptyTableError(String file) {
+        super(file, 0, null);
+    }
+
+    @Override public String getMessage() {
+        return String.format("Table is present in zip file, but it has no entries.");
+    }
+}

--- a/src/main/java/com/conveyal/gtfs/util/json/JsonManager.java
+++ b/src/main/java/com/conveyal/gtfs/util/json/JsonManager.java
@@ -66,6 +66,13 @@ public class JsonManager<T> {
         return ow.writeValueAsString(o);
     }
 
+    public String writePretty(Object o) throws JsonProcessingException {
+        if (o instanceof String) {
+            return (String) o;
+        }
+        return om.writerWithDefaultPrettyPrinter().writeValueAsString(o);
+    }
+
     /**
      * Convert an object to its JSON representation
      * @param o the object to convert


### PR DESCRIPTION
- adds empty table error when a table has no rows or only header
- pretty prints json validation errors (if validate flag used)