### PR TITLE
Fix run command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ $ git clone https://github.com/conveyal/gtfs-lib.git
 $ cd gtfs-lib
 ## build the jar
 $ mvn package
-## run the validation suite on a GTFS file and save the result to result.json
-$ java -jar -validate target/gtfs-lib-shaded.jar /path/to/gtfs.zip /path/to/result.json
+## run the validation suite on a GTFS file and save the result to result.json - change the version number to match file name in /target
+$ java -jar target/gtfs-lib-2.2.0-SNAPSHOT-shaded.jar -validate /path/to/gtfs.zip /path/to/result.json
 ```
 
 ### Validation result


### PR DESCRIPTION
* "-validate" must come after the JAR file name, otherwise you get an error "Error: A fatal exception has occurred. Program will exit. Unrecognized option: -validate"
* Specify exact version in file name example, with a note that it should be changed to match /target directory