### PR TITLE
fix(Route): Fix agency NPE issue

### DIFF
--- a/src/main/java/com/conveyal/gtfs/error/NoAgencyInFeedError.java
+++ b/src/main/java/com/conveyal/gtfs/error/NoAgencyInFeedError.java
@@ -5,14 +5,14 @@ import com.conveyal.gtfs.validator.model.Priority;
 /**
  * Created by landon on 5/2/17.
  */
-public class NoOperatorInFeedError extends GTFSError {
+public class NoAgencyInFeedError extends GTFSError {
     public final Priority priority = Priority.HIGH;
 
-    public NoOperatorInFeedError() {
+    public NoAgencyInFeedError() {
         super("agency", 0, "agency_id");
     }
 
     @Override public String getMessage() {
-        return String.format("No operator listed in feed (must have at least one).");
+        return String.format("No agency listed in feed (must have at least one).");
     }
 }

--- a/src/main/java/com/conveyal/gtfs/error/NoOperatorInFeedError.java
+++ b/src/main/java/com/conveyal/gtfs/error/NoOperatorInFeedError.java
@@ -1,0 +1,18 @@
+package com.conveyal.gtfs.error;
+
+import com.conveyal.gtfs.validator.model.Priority;
+
+/**
+ * Created by landon on 5/2/17.
+ */
+public class NoOperatorInFeedError extends GTFSError {
+    public final Priority priority = Priority.HIGH;
+
+    public NoOperatorInFeedError() {
+        super("agency", 0, "agency_id");
+    }
+
+    @Override public String getMessage() {
+        return String.format("No operator listed in feed (must have at least one).");
+    }
+}

--- a/src/main/java/com/conveyal/gtfs/model/Route.java
+++ b/src/main/java/com/conveyal/gtfs/model/Route.java
@@ -1,7 +1,7 @@
 package com.conveyal.gtfs.model;
 
 import com.conveyal.gtfs.GTFSFeed;
-import com.conveyal.gtfs.error.NoOperatorInFeedError;
+import com.conveyal.gtfs.error.NoAgencyInFeedError;
 
 import java.io.IOException;
 import java.net.URL;
@@ -55,7 +55,7 @@ public class Route extends Entity { // implements Entity.Factory<Route>
                 if (feed.agency.size() == 1) {
                     r.agency_id = feed.agency.values().iterator().next().agency_id;
                 } else if (feed.agency.isEmpty()) {
-                    feed.errors.add(new NoOperatorInFeedError());
+                    feed.errors.add(new NoAgencyInFeedError());
                 }
             } else {
                 r.agency_id = agency.agency_id;

--- a/src/main/java/com/conveyal/gtfs/model/Route.java
+++ b/src/main/java/com/conveyal/gtfs/model/Route.java
@@ -1,6 +1,7 @@
 package com.conveyal.gtfs.model;
 
 import com.conveyal.gtfs.GTFSFeed;
+import com.conveyal.gtfs.error.NoOperatorInFeedError;
 
 import java.io.IOException;
 import java.net.URL;
@@ -49,12 +50,16 @@ public class Route extends Entity { // implements Entity.Factory<Route>
             r.route_id = getStringField("route_id", true);
             Agency agency = getRefField("agency_id", false, feed.agency);
 
-            // if there is only one agency, associate with it automatically
-            // TODO: what will this do if the agency and the route have agency_ids but they do not match?
-            if (agency == null && feed.agency.size() == 1)
-                agency = feed.agency.values().iterator().next();
-
-            r.agency_id = agency.agency_id;
+            if (agency == null) {
+                // if there is only one agency, associate with it automatically
+                if (feed.agency.size() == 1) {
+                    r.agency_id = feed.agency.values().iterator().next().agency_id;
+                } else if (feed.agency.isEmpty()) {
+                    feed.errors.add(new NoOperatorInFeedError());
+                }
+            } else {
+                r.agency_id = agency.agency_id;
+            }
 
             r.route_short_name = getStringField("route_short_name", false); // one or the other required, needs a special validator
             r.route_long_name = getStringField("route_long_name", false);


### PR DESCRIPTION
This fix is for feeds that have no agency records. When the agency_id for a route has a missing
reference, it is assigned the first agency if there is only one agency. If there are no agencies
present, the field is left null and a NoOperatorInFeedError is stored.

Fixes #40