### PR TITLE
Fare Attributes : missing transfers means "unlimited"

### DIFF
--- a/src/main/java/com/conveyal/gtfs/model/FareAttribute.java
+++ b/src/main/java/com/conveyal/gtfs/model/FareAttribute.java
@@ -10,7 +10,7 @@ import java.util.Map;
 public class FareAttribute extends Entity {
 
     private static final long serialVersionUID = 2157859372072056891L;
-    public static final int UNLIMITED_TRANSFERS = 3;
+    public static final int UNLIMITED_TRANSFERS = Integer.MAX_VALUE;
     public String fare_id;
     public double price;
     public String currency_type;
@@ -47,7 +47,7 @@ public class FareAttribute extends Entity {
                 fa.price = getDoubleField("price", true, 0, Integer.MAX_VALUE);
                 fa.currency_type = getStringField("currency_type", true);
                 fa.payment_method = getIntField("payment_method", true, 0, 1);
-                fa.transfers = getIntField("transfers", false, 0, 10, UNLIMITED_TRANSFERS); // missing means "unlimited" in this case (rather than 0), supply default value 3 to mean unlimited
+                fa.transfers = getIntField("transfers", false, 0, 10, UNLIMITED_TRANSFERS); // in the GTFS spec, a missing value means "unlimited", so we default to UNLIMITED_TRANSFERS (or MAX_INT) when no value is found
                 fa.transfer_duration = getIntField("transfer_duration", false, 0, 24 * 60 * 60);
                 fa.feed = feed;
                 fa.feed_id = feed.feedId;

--- a/src/main/java/com/conveyal/gtfs/model/FareAttribute.java
+++ b/src/main/java/com/conveyal/gtfs/model/FareAttribute.java
@@ -46,7 +46,7 @@ public class FareAttribute extends Entity {
                 fa.price = getDoubleField("price", true, 0, Integer.MAX_VALUE);
                 fa.currency_type = getStringField("currency_type", true);
                 fa.payment_method = getIntField("payment_method", true, 0, 1);
-                fa.transfers = getIntField("transfers", false, 0, 10); // TODO missing means "unlimited" in this case (rather than 0), supply default value or just use the NULL to mean unlimited
+                fa.transfers = getIntField("transfers", false, 0, 10, 3); // missing means "unlimited" in this case (rather than 0), supply default value 3 to mean unlimited
                 fa.transfer_duration = getIntField("transfer_duration", false, 0, 24 * 60 * 60);
                 fa.feed = feed;
                 fa.feed_id = feed.feedId;

--- a/src/main/java/com/conveyal/gtfs/model/FareAttribute.java
+++ b/src/main/java/com/conveyal/gtfs/model/FareAttribute.java
@@ -10,6 +10,7 @@ import java.util.Map;
 public class FareAttribute extends Entity {
 
     private static final long serialVersionUID = 2157859372072056891L;
+    public static final int UNLIMITED_TRANSFERS = 3;
     public String fare_id;
     public double price;
     public String currency_type;
@@ -46,7 +47,7 @@ public class FareAttribute extends Entity {
                 fa.price = getDoubleField("price", true, 0, Integer.MAX_VALUE);
                 fa.currency_type = getStringField("currency_type", true);
                 fa.payment_method = getIntField("payment_method", true, 0, 1);
-                fa.transfers = getIntField("transfers", false, 0, 10, 3); // missing means "unlimited" in this case (rather than 0), supply default value 3 to mean unlimited
+                fa.transfers = getIntField("transfers", false, 0, 10, UNLIMITED_TRANSFERS); // missing means "unlimited" in this case (rather than 0), supply default value 3 to mean unlimited
                 fa.transfer_duration = getIntField("transfer_duration", false, 0, 24 * 60 * 60);
                 fa.feed = feed;
                 fa.feed_id = feed.feedId;


### PR DESCRIPTION
Missing transfers means "unlimited" in this case use value grater-than 2 (for now i supplies/mapped it to 3), rather than 0. As 0 already has some meaning, so it cause bug/mislead the lib user.