### PR TITLE
Integrate graphql API directly into gtfs-lib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -338,5 +338,11 @@
       <artifactId>commons-dbcp2</artifactId>
       <version>2.1.1</version>
     </dependency>
+    <!-- GraphQL for Java, without HTTP layer, just query and response handling. -->
+    <dependency>
+      <groupId>com.graphql-java</groupId>
+      <artifactId>graphql-java</artifactId>
+      <version>4.2</version>
+    </dependency>
   </dependencies>
 </project>

--- a/src/main/java/com/conveyal/gtfs/graphql/GTFSGraphQL.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/GTFSGraphQL.java
@@ -1,0 +1,41 @@
+package com.conveyal.gtfs.graphql;
+
+import com.conveyal.gtfs.GTFS;
+import graphql.GraphQL;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+/**
+ * This provides a GraphQL API around the gtfs-lib JDBC storage.
+ * This just makes a Java API with the right schema available, which uses String requests and responses.
+ * To make this into a web API you need to wrap it in an HTTP framework / server.
+ */
+public class GTFSGraphQL {
+
+    private static DataSource dataSource;
+
+    // TODO Is it correct to share one of these objects between many instances? Is it supposed to be long-lived or threadsafe?
+    // Analysis-backend creates a new GraphQL object on every request.
+    private static GraphQL GRAPHQL;
+
+    /** Username and password can be null if connecting to a local instance with host-based authentication. */
+    public static void initialize (DataSource dataSource) {
+        GTFSGraphQL.dataSource = dataSource;
+        GRAPHQL = new GraphQL(GraphQLGtfsSchema.feedBasedSchema);
+    }
+
+    public static Connection getConnection() {
+        try {
+            return dataSource.getConnection();
+        } catch (SQLException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    public static GraphQL getGraphQl () {
+        return GRAPHQL;
+    }
+
+}

--- a/src/main/java/com/conveyal/gtfs/graphql/GraphQLGtfsSchema.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/GraphQLGtfsSchema.java
@@ -1,0 +1,388 @@
+package com.conveyal.gtfs.graphql;
+
+import com.conveyal.gtfs.graphql.fetchers.ErrorCountFetcher;
+import com.conveyal.gtfs.graphql.fetchers.FeedFetcher;
+import com.conveyal.gtfs.graphql.fetchers.JDBCFetcher;
+import com.conveyal.gtfs.graphql.fetchers.MapFetcher;
+import com.conveyal.gtfs.graphql.fetchers.RowCountFetcher;
+import com.conveyal.gtfs.graphql.fetchers.SQLColumnFetcher;
+import com.conveyal.gtfs.graphql.fetchers.SourceObjectFetcher;
+import graphql.Scalars;
+import graphql.schema.GraphQLList;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.GraphQLTypeReference;
+
+import static com.conveyal.gtfs.graphql.GraphQLUtil.intArg;
+import static com.conveyal.gtfs.graphql.GraphQLUtil.intt;
+import static com.conveyal.gtfs.graphql.GraphQLUtil.multiStringArg;
+import static com.conveyal.gtfs.graphql.GraphQLUtil.string;
+import static com.conveyal.gtfs.graphql.GraphQLUtil.stringArg;
+import static graphql.Scalars.GraphQLFloat;
+import static graphql.Scalars.GraphQLInt;
+import static graphql.Scalars.GraphQLString;
+import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
+import static graphql.schema.GraphQLObjectType.newObject;
+
+/**
+ * This defines the types for our GraphQL API, and wires them up to functions that can fetch data from JDBC databases.
+ */
+public class GraphQLGtfsSchema {
+
+    // The order here is critical. Each new type that's defined can refer to other types directly by object
+    // reference or by name. Names can only be used for types that are already reachable recursively by
+    // reference from the top of the schema. So you want as many direct references as you can.
+    // It really seems like all this should be done automatically, maybe we should be using a text schema
+    // instead of code.
+    // I do wonder whether these should all be statically initialized. Doing this in a non-static context
+    // in one big block with local variables, the dependencies would be checked by compiler.
+    // The order:
+    // Instantiate starting with leaf nodes (reverse topological sort of the dependency graph).
+    // All forward references must use names and GraphQLTypeReference.
+    // Additionally the tree will be explored once top-down following explicit object references, and only
+    // objects reached that way will be available by name reference.
+    // Another way to accomplish this would be to use name references in every definition except the top level,
+    // and make a dummy declaration that will call them all to be pulled in by reference at once.
+
+
+    // The old types are defined in separate class files. I'm defining new ones here.
+
+    // by using static fields to hold these types, backward references are enforced. a few forward references are inserted explicitly.
+
+    // Represents rows from trips.txt
+    public static final GraphQLObjectType tripType = newObject()
+            .name("trip")
+            .field(MapFetcher.field("trip_id"))
+            .field(MapFetcher.field("trip_headsign"))
+            .field(MapFetcher.field("trip_short_name"))
+            .field(MapFetcher.field("block_id"))
+            .field(MapFetcher.field("direction_id", GraphQLInt))
+            .field(MapFetcher.field("route_id"))
+            .field(MapFetcher.field("service_id"))
+            .field(MapFetcher.field("pattern_id"))
+            .field(newFieldDefinition()
+                    .name("stop_times")
+                    // forward reference to the as yet undefined stopTimeType
+                    .type(new GraphQLList(new GraphQLTypeReference("stopTime")))
+                    .dataFetcher(new JDBCFetcher("stop_times", "trip_id"))
+                    .build()
+            )
+//            // some pseudo-fields to reduce the amount of data that has to be fetched over GraphQL to summarize
+//            .field(newFieldDefinition()
+//                    .name("start_time")
+//                    .type(GraphQLInt)
+//                    .dataFetcher(TripDataFetcher::getStartTime)
+//                    .build()
+//            )
+//            .field(newFieldDefinition()
+//                    .name("duration")
+//                    .type(GraphQLInt)
+//                    .dataFetcher(TripDataFetcher::getDuration)
+//                    .build()
+//            )
+            .build();
+
+
+    // Represents rows from stop_times.txt
+    public static final GraphQLObjectType stopTimeType = newObject().name("stopTime")
+            .field(MapFetcher.field("trip_id"))
+            .field(MapFetcher.field("stop_id"))
+            .field(MapFetcher.field("stop_sequence", GraphQLInt))
+            .field(MapFetcher.field("arrival_time", GraphQLInt))
+            .field(MapFetcher.field("departure_time", GraphQLInt))
+            .field(MapFetcher.field("stop_headsign"))
+            .field(MapFetcher.field("shape_dist_traveled", GraphQLFloat))
+            .build();
+
+    /**
+     * Represents each stop in a list of stops within a pattern.
+     * We could return just a list of StopIDs within the pattern (a JSON array of strings) but
+     * that structure would prevent us from joining tables and returning additional stop details
+     * like lat and lon, or pickup and dropoff types if we add those to the pattern signature.
+     */
+    public static final GraphQLObjectType patternStopType = newObject().name("patternStop")
+            .field(MapFetcher.field("pattern_id"))
+            .field(MapFetcher.field("stop_id"))
+            .field(MapFetcher.field("stop_sequence", GraphQLInt))
+            .build();
+
+    // Represents rows from routes.txt
+    public static final GraphQLObjectType routeType = newObject().name("route")
+            .description("A line from a GTFS routes.txt table")
+            .field(MapFetcher.field("line_number", Scalars.GraphQLInt))
+            .field(MapFetcher.field("agency_id"))
+            .field(MapFetcher.field("route_id"))
+            .field(MapFetcher.field("route_short_name"))
+            .field(MapFetcher.field("route_long_name"))
+            .field(MapFetcher.field("route_desc"))
+            .field(MapFetcher.field("route_url"))
+            // TODO route_type as enum or int
+            .field(MapFetcher.field("route_type"))
+            .field(MapFetcher.field("route_color"))
+            .field(MapFetcher.field("route_text_color"))
+            .field(newFieldDefinition()
+                    .type(new GraphQLList(tripType))
+                    .name("trips")
+                    .argument(multiStringArg("trip_id"))
+                    .dataFetcher(new JDBCFetcher("trips", "route_id"))
+                    .build()
+            )
+            .field(newFieldDefinition()
+                    .type(new GraphQLList(new GraphQLTypeReference("pattern")))
+                    .name("patterns")
+                    .argument(multiStringArg("pattern_id"))
+                    .dataFetcher(new JDBCFetcher("patterns", "route_id"))
+                    .build()
+            )
+            .field(RowCountFetcher.field("count", "routes"))
+            .build();
+
+    // Represents rows from stops.txt
+    // Contains a reference to stopTimeType and routeType
+    public static final GraphQLObjectType stopType = newObject().name("stop")
+            .description("A GTFS stop object")
+            .field(MapFetcher.field("stop_id"))
+            .field(MapFetcher.field("stop_name"))
+            .field(MapFetcher.field("stop_code"))
+            .field(MapFetcher.field("stop_desc"))
+            .field(MapFetcher.field("stop_lon", GraphQLFloat))
+            .field(MapFetcher.field("stop_lat", GraphQLFloat))
+            .field(MapFetcher.field("zone_id"))
+            .field(MapFetcher.field("stop_url"))
+            .field(MapFetcher.field("stop_timezone"))
+//            .field(newFieldDefinition()
+//                    .name("stop_times")
+//                    .description("The list of stop_times for a stop")
+//                    .type(new GraphQLList(GraphQLGtfsSchema.stopTimeType))
+//                    .argument(stringArg("date"))
+//                    .argument(longArg("from"))
+//                    .argument(longArg("to"))
+//                    .dataFetcher(StopTimeFetcher::fromStop)
+//                    .build()
+//            )
+//            .field(newFieldDefinition()
+//                    .name("routes")
+//                    .description("The list of routes that serve a stop")
+//                    .type(new GraphQLList(GraphQLGtfsSchema.routeType))
+//                    .argument(multiStringArg("route_id"))
+//                    .dataFetcher(RouteFetcher::fromStop)
+//                    .build()
+//            )
+            .build();
+
+    /**
+     * The GraphQL API type representing entries in the table of errors encountered while loading or validating a feed.
+     */
+    public static GraphQLObjectType validationErrorType = newObject().name("validationError")
+            .description("An error detected when loading or validating a feed.")
+            .field(MapFetcher.field("error_id", GraphQLInt))
+            .field(MapFetcher.field("error_type"))
+            .field(MapFetcher.field("entity_type"))
+            .field(MapFetcher.field("line_number", GraphQLInt))
+            .field(MapFetcher.field("entity_id"))
+            .field(MapFetcher.field("entity_sequence", GraphQLInt))
+            .field(MapFetcher.field("bad_value"))
+            .build();
+
+    /**
+     * The GraphQL API type representing counts of rows in the various GTFS tables.
+     * The context here for fetching subfields is the feedType. A special dataFetcher is used to pass that identical
+     * context down.
+     */
+    public static GraphQLObjectType rowCountsType = newObject().name("rowCounts")
+            .description("Counts of rows in the various GTFS tables.")
+            .field(RowCountFetcher.field("stops"))
+            .field(RowCountFetcher.field("trips"))
+            .field(RowCountFetcher.field("routes"))
+            .field(RowCountFetcher.field("stop_times"))
+            .field(RowCountFetcher.field("agency"))
+            .field(RowCountFetcher.field("calendar"))
+            .field(RowCountFetcher.field("calendar_dates"))
+            .field(RowCountFetcher.field("errors"))
+            .build();
+
+    /**
+     * GraphQL does not have a type for arbitrary maps (String -> X). Such maps must be expressed as a list of
+     * key-value pairs. This is probably intended to protect us from ourselves (sending untyped data) but it just
+     * leads to silly workarounds like this.
+     */
+    public static GraphQLObjectType errorCountType = newObject().name("errorCount")
+            .description("Quantity of validation errors of a specific type.")
+            .field(string("type"))
+            .field(intt("count"))
+            .field(string("message"))
+            .build();
+
+
+    /**
+     * The GraphQL API type representing a unique sequence of stops on a route. This is used to group trips together.
+     */
+    public static GraphQLObjectType patternType = newObject().name("pattern")
+            .description("A sequence of stops that characterizes a set of trips on a single route.")
+            .field(MapFetcher.field("pattern_id"))
+            .field(MapFetcher.field("route_id"))
+            .field(MapFetcher.field("description"))
+            .field(newFieldDefinition()
+                .name("stops")
+                .type(new GraphQLList(patternStopType))
+                .dataFetcher(new JDBCFetcher("pattern_stops", "pattern_id"))
+                .build())
+            .field(newFieldDefinition()
+                .name("trips")
+                .type(new GraphQLList(tripType))
+                .dataFetcher(new JDBCFetcher("trips", "pattern_id"))
+                .build())
+            .build();
+
+    /**
+     * Durations that a service runs on each mode of transport (route_type).
+     */
+    public static final GraphQLObjectType serviceDurationType = newObject().name("serviceDuration")
+            .field(MapFetcher.field("route_type", GraphQLInt))
+            .field(MapFetcher.field("duration_seconds", GraphQLInt))
+            .build();
+
+    /**
+     * The GraphQL API type representing a service (a service_id attached to trips to say they run on certain days).
+     */
+    public static GraphQLObjectType serviceType = newObject().name("service")
+            .description("A group of trips that all run together on certain days.")
+            .field(MapFetcher.field("service_id"))
+            .field(MapFetcher.field("n_days_active"))
+            .field(MapFetcher.field("duration_seconds"))
+            .field(newFieldDefinition()
+                    .name("dates")
+                    .type(new GraphQLList(GraphQLString))
+                    .dataFetcher(new SQLColumnFetcher<String>("service_dates", "service_id", "service_date"))
+                    .build())
+            .field(newFieldDefinition()
+                    .name("trips")
+                    .type(new GraphQLList(tripType))
+                    .dataFetcher(new JDBCFetcher("trips", "service_id"))
+                    .build())
+            .field(newFieldDefinition()
+                    .name("durations")
+                    .type(new GraphQLList(serviceDurationType))
+                    .dataFetcher(new JDBCFetcher("service_durations", "service_id"))
+                    .build())
+            .build();
+
+    /**
+     * The GraphQL API type representing entries in the top-level table listing all the feeds imported into a gtfs-api
+     * database, and with sub-fields for each table of GTFS entities within a single feed.
+     */
+    public static final GraphQLObjectType feedType = newObject().name("feedVersion")
+            // First, the fields present in the top level table.
+            .field(MapFetcher.field("namespace"))
+            .field(MapFetcher.field("feed_id"))
+            .field(MapFetcher.field("feed_version"))
+            .field(MapFetcher.field("filename"))
+            .field(MapFetcher.field("md5"))
+            .field(MapFetcher.field("sha1"))
+            // A field containing row counts for every table.
+            .field(newFieldDefinition()
+                .name("row_counts")
+                .type(rowCountsType)
+                .dataFetcher(new SourceObjectFetcher())
+                .build())
+            // A field containing counts for each type of error independently.
+            .field(newFieldDefinition()
+                .name("error_counts")
+                .type(new GraphQLList(errorCountType))
+                .dataFetcher(new ErrorCountFetcher())
+                .build())
+            // A field for the errors themselves.
+            .field(newFieldDefinition()
+                    .name("errors")
+                    .type(new GraphQLList(validationErrorType))
+                    .argument(stringArg("namespace"))
+                    .argument(multiStringArg("error_type"))
+                    .argument(intArg("limit"))
+                    .argument(intArg("offset"))
+                    .dataFetcher(new JDBCFetcher("errors"))
+                    .build()
+            )
+            // A field containing all the unique stop sequences (patterns) in this feed.
+            .field(newFieldDefinition()
+                .name("patterns")
+                .type(new GraphQLList(patternType))
+                .argument(multiStringArg("pattern_id"))
+                // DataFetchers can either be class instances implementing the interface, or a static function reference
+                .dataFetcher(new JDBCFetcher("patterns"))
+                .build())
+            // Then the fields for the sub-tables within the feed (loaded directly from GTFS).
+            .field(newFieldDefinition()
+                .name("routes")
+                .type(new GraphQLList(GraphQLGtfsSchema.routeType))
+                .argument(stringArg("namespace"))
+                .argument(multiStringArg("route_id"))
+                .argument(intArg("limit"))
+                .argument(intArg("offset"))
+                .dataFetcher(new JDBCFetcher("routes"))
+                .build()
+            )
+            .field(newFieldDefinition()
+                .name("stops")
+                .type(new GraphQLList(GraphQLGtfsSchema.stopType))
+                .argument(stringArg("namespace")) // FIXME maybe these nested namespace arguments are not doing anything.
+                .argument(multiStringArg("stop_id"))
+                .argument(intArg("limit"))
+                .argument(intArg("offset"))
+                .dataFetcher(new JDBCFetcher("stops"))
+                .build()
+            )
+            .field(newFieldDefinition()
+                .name("trips")
+                .type(new GraphQLList(GraphQLGtfsSchema.tripType))
+                .argument(stringArg("namespace"))
+                .argument(multiStringArg("trip_id"))
+                .argument(multiStringArg("route_id"))
+                .argument(intArg("limit"))
+                .argument(intArg("offset"))
+                .dataFetcher(new JDBCFetcher("trips"))
+                .build()
+            )
+            .field(newFieldDefinition()
+                .name("stop_times")
+                .type(new GraphQLList(GraphQLGtfsSchema.stopTimeType))
+                .argument(stringArg("namespace"))
+                .argument(intArg("limit"))
+                .argument(intArg("offset"))
+                .dataFetcher(new JDBCFetcher("stop_times"))
+                .build()
+            )
+            .field(newFieldDefinition()
+                .name("services")
+                .argument(multiStringArg("service_id"))
+                .type(new GraphQLList(GraphQLGtfsSchema.serviceType))
+                .argument(intArg("limit")) // Todo somehow autogenerate these JDBCFetcher builders to include standard params.
+                .argument(intArg("offset"))
+                .dataFetcher(new JDBCFetcher("services"))
+                .build()
+            )
+            .build();
+
+    /**
+     * This is the top-level query - you must always specify a feed to fetch, and then some other things inside that feed.
+     * TODO decide whether to call this feedVersion or feed within gtfs-lib context.
+     */
+    private static GraphQLObjectType feedQuery = newObject()
+            .name("feedQuery")
+            .field(newFieldDefinition()
+                .name("feed")
+                .type(feedType)
+                // We scope to a single feed namespace, otherwise GTFS entity IDs are ambiguous.
+                .argument(stringArg("namespace"))
+                .dataFetcher(new FeedFetcher())
+                .build()
+            )
+            .build();
+
+    /**
+     * This is the new schema as of July 2017, where all sub-entities are wrapped in a feed.
+     * Because all of these fields are static (ugh) this must be declared after the feedQuery it references.
+     */
+    public static final GraphQLSchema feedBasedSchema = GraphQLSchema.newSchema().query(feedQuery).build();
+
+
+}

--- a/src/main/java/com/conveyal/gtfs/graphql/GraphQLUtil.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/GraphQLUtil.java
@@ -1,0 +1,52 @@
+package com.conveyal.gtfs.graphql;
+
+import graphql.schema.FieldDataFetcher;
+import graphql.schema.GraphQLArgument;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLList;
+
+import static graphql.Scalars.GraphQLInt;
+import static graphql.Scalars.GraphQLString;
+import static graphql.schema.GraphQLArgument.newArgument;
+import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
+
+public class GraphQLUtil {
+
+    public static GraphQLFieldDefinition string (String name) {
+        return newFieldDefinition()
+                .name(name)
+                .type(GraphQLString)
+                .dataFetcher(new FieldDataFetcher(name))
+                .build();
+    }
+
+    public static GraphQLFieldDefinition intt (String name) {
+        return newFieldDefinition()
+                .name(name)
+                .type(GraphQLInt)
+                .dataFetcher(new FieldDataFetcher(name))
+                .build();
+    }
+
+    public static GraphQLArgument stringArg (String name) {
+        return newArgument()
+                .name(name)
+                .type(GraphQLString)
+                .build();
+    }
+
+    public static GraphQLArgument multiStringArg (String name) {
+        return newArgument()
+                .name(name)
+                .type(new GraphQLList(GraphQLString))
+                .build();
+    }
+
+    public static GraphQLArgument intArg (String name) {
+        return newArgument()
+                .name(name)
+                .type(GraphQLInt)
+                .build();
+    }
+
+}

--- a/src/main/java/com/conveyal/gtfs/graphql/fetchers/ErrorCountFetcher.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/fetchers/ErrorCountFetcher.java
@@ -1,0 +1,72 @@
+package com.conveyal.gtfs.graphql.fetchers;
+
+import com.conveyal.gtfs.error.NewGTFSErrorType;
+import com.conveyal.gtfs.graphql.GTFSGraphQL;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import org.apache.commons.dbutils.DbUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Get quantity of errors broken down by error type.
+ * GraphQL does not have a type for arbitrary maps (String -> X). Such maps must be expressed as a list of
+ * key-value pairs. This is probably intended to protect us from ourselves (sending untyped data) but it leads to
+ * silly workarounds like this where there are a large number of possible keys.
+ *
+ * "Unfortunately what you'd like to do is not possible. GraphQL requires you to be explicit about specifying which
+ * fields you would like returned from your query."
+ * "Ok, and if I request some object of an unknown form from backend which I'm supposed to proxy or send back?"
+ * "the whole idea of graphql is that there is no such thing as an 'unkown form'".
+ * https://stackoverflow.com/a/34226484/778449
+ */
+public class ErrorCountFetcher implements DataFetcher {
+
+    public static final Logger LOG = LoggerFactory.getLogger(ErrorCountFetcher.class);
+
+    @Override
+    public Object get(DataFetchingEnvironment environment) {
+        List<ErrorCount> errorCounts = new ArrayList();
+        Map<String, Object> parentFeedMap = environment.getSource();
+        String namespace = (String) parentFeedMap.get("namespace");
+        Connection connection = null;
+        try {
+            connection = GTFSGraphQL.getConnection();
+            Statement statement = connection.createStatement();
+            String sql = String.format("select error_type, count(*) from %s.errors group by error_type", namespace);
+            LOG.info("SQL: {}", sql);
+            if (statement.execute(sql)) {
+                ResultSet resultSet = statement.getResultSet();
+                while (resultSet.next()) {
+                    errorCounts.add(new ErrorCount(NewGTFSErrorType.valueOf(resultSet.getString(1)), resultSet.getInt(2)));
+                }
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        } finally {
+            DbUtils.closeQuietly(connection);
+        }
+        return errorCounts;
+    }
+
+    public static class ErrorCount {
+        public NewGTFSErrorType type;
+        public int count;
+        public String message;
+
+        public ErrorCount(NewGTFSErrorType errorType, int count) {
+            this.type = errorType;
+            this.count = count;
+            this.message = errorType.englishMessage;
+        }
+    }
+
+}

--- a/src/main/java/com/conveyal/gtfs/graphql/fetchers/FeedFetcher.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/fetchers/FeedFetcher.java
@@ -1,0 +1,58 @@
+package com.conveyal.gtfs.graphql.fetchers;
+
+import com.conveyal.gtfs.graphql.GTFSGraphQL;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Fetch the summary row for a particular loaded feed, based on its namespace.
+ * This essentially gets the row from the top-level summary table of all feeds that have been loaded into the database.
+ */
+public class FeedFetcher implements DataFetcher {
+
+    public static final Logger LOG = LoggerFactory.getLogger(DataFetcher.class);
+
+    @Override
+    public Map<String, Object> get (DataFetchingEnvironment environment) {
+        String namespace = environment.getArgument("namespace"); // This is the unique table prefix (the "schema").
+        StringBuilder sqlBuilder = new StringBuilder();
+        sqlBuilder.append(String.format("select * from feeds where namespace = '%s'", namespace));
+        Connection connection = null;
+        try {
+            connection = GTFSGraphQL.getConnection();
+            Statement statement = connection.createStatement();
+            LOG.info("SQL: {}", sqlBuilder.toString());
+            if (statement.execute(sqlBuilder.toString())) {
+                ResultSet resultSet = statement.getResultSet();
+                ResultSetMetaData meta = resultSet.getMetaData();
+                int nColumns = meta.getColumnCount();
+                // Iterate over result rows
+                while (resultSet.next()) {
+                    // Create a Map to hold the contents of this row, injecting the feed_id into every map
+                    Map<String, Object> resultMap = new HashMap<>();
+                    resultMap.put("namespace", namespace);
+                    for (int i = 1; i < nColumns; i++) {
+                        resultMap.put(meta.getColumnName(i), resultSet.getObject(i));
+                    }
+                    connection.close();
+                    // FIXME return inside a while loop? This would only hit the first item.
+                    return resultMap;
+                }
+            }
+            throw new RuntimeException("No rows found.");
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/src/main/java/com/conveyal/gtfs/graphql/fetchers/JDBCFetcher.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/fetchers/JDBCFetcher.java
@@ -1,0 +1,207 @@
+package com.conveyal.gtfs.graphql.fetchers;
+
+import com.conveyal.gtfs.graphql.GTFSGraphQL;
+import com.conveyal.gtfs.graphql.GraphQLGtfsSchema;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLList;
+import org.apache.commons.dbutils.DbUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.conveyal.gtfs.graphql.GraphQLUtil.multiStringArg;
+import static com.conveyal.gtfs.graphql.GraphQLUtil.stringArg;
+import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
+
+/**
+ * A generic fetcher to get fields out of an SQL database table.
+ */
+public class JDBCFetcher implements DataFetcher<List<Map<String, Object>>> {
+
+    public static final Logger LOG = LoggerFactory.getLogger(JDBCFetcher.class);
+
+    // Make this an option to the GraphQL query.
+    public static final int DEFAULT_ROWS_TO_FETCH = 50;
+    public static final int MAX_ROWS_TO_FETCH = 500;
+
+    public final String tableName;
+    public final String parentJoinField;
+
+    // Supply an SQL result row -> Object transformer
+
+    /**
+     * Constructor for tables that don't need any restriction by a where clause based on the enclosing entity.
+     * These would typically be at the topmost level, directly inside a feed rather than nested in some GTFS entity type.
+     */
+    public JDBCFetcher (String tableName) {
+        this(tableName, null);
+    }
+
+    /**
+     * @param tableName the database table from which to fetch rows.
+     * @param parentJoinField The field in the enclosing level of the Graphql query to use in a where clause.
+     *        This allows e.g. selecting all the stop_times within a trip, using the enclosing trip's trip_id.
+     *        If null, no such clause is added.
+     */
+    public JDBCFetcher (String tableName, String parentJoinField) {
+        this.tableName = tableName;
+        this.parentJoinField = parentJoinField;
+    }
+
+    // We can't automatically generate JDBCFetcher based field definitions for inclusion in a GraphQL schema (as we
+    // do for MapFetcher for example). This is because we need custom inclusion of sub-tables in each table type.
+    // Still maybe we could make the most basic ones this way (automatically). Keeping this function as an example.
+    public static GraphQLFieldDefinition field (String tableName) {
+        return newFieldDefinition()
+                .name(tableName)
+                .type(new GraphQLList(GraphQLGtfsSchema.routeType))
+                .argument(stringArg("namespace"))
+                .argument(multiStringArg("route_id"))
+                .dataFetcher(new JDBCFetcher(tableName, null))
+                .build();
+    }
+
+    // Horrifically, we're going from SQL response to Gtfs-lib Java model object to GraphQL Java object to JSON.
+    // What if we did direct SQL->JSON?
+    // Could we transform JDBC ResultSets directly to JSON?
+    // With Jackson streaming API we can make a ResultSet serializer: https://stackoverflow.com/a/8120442
+
+    // We could apply a transformation from ResultSet to Gtfs-lib model object, but then more DataFetchers
+    // need to be defined to pull the fields out of those model objects. I'll try to skip those intermediate objects.
+
+    // Unfortunately we can't just apply DataFetchers directly to the ResultSets because they're cursors, and we'd
+    // have to somehow advance them at the right moment. So we need to transform the SQL results into fully materialized
+    // Java objects, then transform those into GraphQL fields. Fortunately the final transformation is trivial fetching
+    // from a Map<String, Object>.
+    // But what are the internal GraphQL objects, i.e. what does an ExecutionResult return? Are they Map<String, Object>?
+
+    @Override
+    public List<Map<String, Object>> get (DataFetchingEnvironment environment) {
+
+        // This will contain one Map<String, Object> for each row fetched from the database table.
+        List<Map<String, Object>> results = new ArrayList<>();
+
+        // Apparently you can't get the arguments from the parent - how do you have arguments on sub-fields?
+        // It looks like you have to redefine the argument on each subfield and pass it explicitly in the Graphql request.
+
+        // String namespace = environment.getArgument("namespace"); // This is going to be the unique prefix, not the feedId in the usual sense
+        // This DataFetcher only makes sense when the enclosing parent object is a feed or something in a feed.
+        // So it should always be represented as a map with a namespace key.
+
+        // GetSource is the context in which this this DataFetcher has been created, in this case a map representing the parent feed.
+        Map<String, Object> parentEntityMap = environment.getSource();
+        String namespace = (String) parentEntityMap.get("namespace");
+        StringBuilder sqlBuilder = new StringBuilder();
+
+        // We could select only the requested fields by examining environment.getFields(), but we just get them all.
+        // The advantage of selecting * is that we don't need to validate the field names.
+        // All the columns will be loaded into the Map<String, Object>,
+        // but only the requested fields will be fetched from that Map using a MapFetcher.
+        sqlBuilder.append(String.format("select * from %s.%s", namespace, tableName));
+
+        // We will build up additional sql clauses in this List.
+        List<String> conditions = new ArrayList<>();
+
+        // If we are fetching an item nested within a GTFS entity in the Graphql query, we want to add an SQL "where"
+        // clause. This could conceivably be done automatically, but it's clearer to just express the intent.
+        // Note, this is assuming the type of the field in the parent is a string.
+        if (parentJoinField != null) {
+            Map<String, Object> enclosingEntity = environment.getSource();
+            // FIXME SQL injection: enclosing entity's ID could contain malicious character sequences; quote and sanitize the string.
+            conditions.add(String.join(" = ", parentJoinField, quote(enclosingEntity.get(parentJoinField).toString())));
+        }
+        for (String key : environment.getArguments().keySet()) {
+            // Limit and Offset arguments are for pagination. All others become "where X in A, B, C" clauses.
+            if ("limit".equals(key) || "offset".equals(key)) continue;
+            List<String> values = (List<String>) environment.getArguments().get(key);
+            if (values != null && !values.isEmpty()) conditions.add(makeInClause(key, values));
+        }
+        if ( ! conditions.isEmpty()) {
+            sqlBuilder.append(" where ");
+            sqlBuilder.append(String.join(" and ", conditions));
+        }
+        Integer limit = (Integer) environment.getArguments().get("limit");
+        if (limit == null) {
+            limit = DEFAULT_ROWS_TO_FETCH;
+        }
+        if (limit > MAX_ROWS_TO_FETCH) {
+            limit = MAX_ROWS_TO_FETCH;
+        }
+        sqlBuilder.append(" limit " + limit);
+        Integer offset = (Integer) environment.getArguments().get("offset");
+        if (offset != null && offset >= 0) {
+            sqlBuilder.append(" offset " + offset);
+        }
+        Connection connection = null;
+        try {
+            connection = GTFSGraphQL.getConnection();
+            Statement statement = connection.createStatement();
+            // This logging produces a lot of noise during testing due to large numbers of joined sub-queries
+            // LOG.info("SQL: {}", sqlBuilder.toString());
+            if (statement.execute(sqlBuilder.toString())) {
+                ResultSet resultSet = statement.getResultSet();
+                ResultSetMetaData meta = resultSet.getMetaData();
+                int nColumns = meta.getColumnCount();
+                // Iterate over result rows
+                while (resultSet.next()) {
+                    // Create a Map to hold the contents of this row, injecting the sql schema namespace into every map
+                    Map<String, Object> resultMap = new HashMap<>();
+                    resultMap.put("namespace", namespace);
+                    // One-based iteration: start at one and use <=.
+                    for (int i = 1; i <= nColumns; i++) {
+                        resultMap.put(meta.getColumnName(i), resultSet.getObject(i));
+                    }
+                    results.add(resultMap);
+                }
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        } finally {
+            DbUtils.closeQuietly(connection);
+        }
+        // Return a List of Maps, one Map for each row in the result.
+        return results;
+    }
+
+    private String makeInClause(String key, List<String> strings) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(key);
+        if (strings.size() == 1) {
+            sb.append(" = ");
+            quote(sb, strings.get(0));
+        } else {
+            sb.append(" in (");
+            for (int i = 0; i < strings.size(); i++) {
+                if (i > 0) sb.append(",");
+                quote(sb, strings.get(i));
+            }
+            sb.append(")");
+        }
+        return sb.toString();
+    }
+
+    // TODO SQL sanitization to avoid injection
+    private void quote(StringBuilder sb, String string) {
+        sb.append("'");
+        sb.append(string);
+        sb.append("'");
+    }
+
+    private String quote (String string) {
+        StringBuilder sb = new StringBuilder();
+        quote(sb, string);
+        return sb.toString();
+    }
+
+}

--- a/src/main/java/com/conveyal/gtfs/graphql/fetchers/MapFetcher.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/fetchers/MapFetcher.java
@@ -1,0 +1,44 @@
+package com.conveyal.gtfs.graphql.fetchers;
+
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLOutputType;
+
+import java.util.Map;
+
+import static graphql.Scalars.GraphQLString;
+import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
+
+/**
+ * This just grabs an entry out of a Map<String, Object>
+ * It allows pulling a single field out of the result of a DataFetcher that always returns all fields
+ * (like our JDBC SQL fetcher).
+ */
+public class MapFetcher implements DataFetcher {
+
+    final String key;
+
+    public MapFetcher(String key) {
+        this.key = key;
+    }
+
+    @Override
+    public Object get(DataFetchingEnvironment dataFetchingEnvironment) {
+        Object source = dataFetchingEnvironment.getSource();
+        return ((Map<String, Object>)source).get(key);
+    }
+
+    public static GraphQLFieldDefinition field(String name) {
+        return field(name, GraphQLString);
+    }
+
+    public static GraphQLFieldDefinition field(String name, GraphQLOutputType type) {
+        return newFieldDefinition()
+                .name(name)
+                .type(type)
+                .dataFetcher(new MapFetcher(name))
+                .build();
+    }
+
+}

--- a/src/main/java/com/conveyal/gtfs/graphql/fetchers/RowCountFetcher.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/fetchers/RowCountFetcher.java
@@ -1,0 +1,79 @@
+package com.conveyal.gtfs.graphql.fetchers;
+
+import com.conveyal.gtfs.graphql.GTFSGraphQL;
+import com.conveyal.gtfs.loader.JDBCTableReader;
+import graphql.Scalars;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.GraphQLFieldDefinition;
+import org.apache.commons.dbutils.DbUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Map;
+
+import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
+
+/**
+ * Get quantity of rows in the given table.
+ */
+public class RowCountFetcher implements DataFetcher {
+
+    public static final Logger LOG = LoggerFactory.getLogger(RowCountFetcher.class);
+
+    private final String tableName;
+
+    public RowCountFetcher(String tableName) {
+        this.tableName = tableName;
+    }
+
+    @Override
+    public Integer get(DataFetchingEnvironment environment) {
+        Map<String, Object> parentFeedMap = environment.getSource();
+        String namespace = (String) parentFeedMap.get("namespace");
+        Connection connection = null;
+        try {
+            connection = GTFSGraphQL.getConnection();
+            Statement statement = connection.createStatement();
+            String sql = String.format("select count(*) from %s.%s", namespace, tableName);
+            if (statement.execute(sql)) {
+                ResultSet resultSet = statement.getResultSet();
+                resultSet.next();
+                return resultSet.getInt(1);
+            }
+        } catch (SQLException e) {
+            // In case the table doesn't exist in this feed, just return zero and don't print noise to the log.
+            // Unfortunately JDBC doesn't seem to define reliable error codes.
+            if (! JDBCTableReader.SQL_STATE_UNDEFINED_TABLE.equals(e.getSQLState())) {
+                e.printStackTrace();
+            }
+        } finally {
+            DbUtils.closeQuietly(connection);
+        }
+        return 0;
+    }
+
+    /**
+     * Convenience method to create a field in a GraphQL schema that fetches the number of rows in a table.
+     * Must be on a type that has a "namespace" field for context.
+     */
+    public static GraphQLFieldDefinition field (String fieldName, String tableName) {
+        return newFieldDefinition()
+                .name(fieldName)
+                .type(Scalars.GraphQLInt)
+                .dataFetcher(new RowCountFetcher(tableName))
+                .build();
+    }
+
+    /**
+     * For cases where the GraphQL field name is the same as the table name itself.
+     */
+    public static GraphQLFieldDefinition field (String tableName) {
+        return field(tableName, tableName);
+    }
+
+}

--- a/src/main/java/com/conveyal/gtfs/graphql/fetchers/SQLColumnFetcher.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/fetchers/SQLColumnFetcher.java
@@ -1,0 +1,45 @@
+package com.conveyal.gtfs.graphql.fetchers;
+
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This wraps an SQL row fetcher, extracting only a single column of the specified type.
+ * Because there's only one column, it collapses the result down into a list of elements of that column's type,
+ * rather than a list of maps (one for each row) as the basic SQL fetcher does.
+ */
+public class SQLColumnFetcher<T> implements DataFetcher<List<T>> {
+
+    public static final Logger LOG = LoggerFactory.getLogger(SQLColumnFetcher.class);
+
+    public final String columnName;
+
+    private final JDBCFetcher jdbcFetcher;
+
+    /**
+     * Constructor for tables that don't need any restriction by a where clause based on the enclosing entity.
+     * These would typically be at the topmost level, directly inside a feed rather than nested in some GTFS entity type.
+     */
+    public SQLColumnFetcher(String tableName, String parentJoinField, String columnName) {
+        this.columnName = columnName;
+        this.jdbcFetcher = new JDBCFetcher(tableName, parentJoinField);
+
+    }
+
+    @Override
+    public List<T> get (DataFetchingEnvironment environment) {
+        List<T> result = new ArrayList<>();
+        // Ideally we'd only fetch one column in the wrapped row fetcher.
+        for (Map<String, Object> row : jdbcFetcher.get(environment)) {
+            result.add((T)row.get(columnName));
+        }
+        return result;
+    }
+
+}

--- a/src/main/java/com/conveyal/gtfs/graphql/fetchers/SourceObjectFetcher.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/fetchers/SourceObjectFetcher.java
@@ -1,0 +1,20 @@
+package com.conveyal.gtfs.graphql.fetchers;
+
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+
+import java.util.Map;
+
+/**
+ * This is a special data fetcher for cases where the sub-object context is exactly the same as the parent object.
+ * This is useful for grouping fields together. For example, row counts of tables within a GTFS feed are conceptually
+ * directly under the feed, but we group them together in a sub-object for clarity.
+ */
+public class SourceObjectFetcher implements DataFetcher {
+
+    @Override
+    public Map<String, Object> get(DataFetchingEnvironment dataFetchingEnvironment) {
+        return dataFetchingEnvironment.getSource();
+    }
+
+}

--- a/src/main/java/com/conveyal/gtfs/graphql/package-info.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * This package contains classes that define a GraphQL interface to our database of GTFS data.
+ * The gtfs-lib project does not contain the HTML layer to access this API - that can be provided by any project
+ * that includes gtfs-lib as a dependency.
+ * Created by abyrd on 2017-11-21
+ */
+package com.conveyal.gtfs.graphql;


### PR DESCRIPTION
It used to be in a separate project called gtfs-api.
We just put the Java graphql api definition in this project, which takes string queries and returns Object responses.
Whatever project includes gtfs-lib will need to provide an HTTP layer on top of this using some web server or framework.