### PR TITLE
A few fixes for the GTFS Editor

### DIFF
--- a/src/main/java/com/conveyal/gtfs/loader/JdbcGtfsExporter.java
+++ b/src/main/java/com/conveyal/gtfs/loader/JdbcGtfsExporter.java
@@ -74,8 +74,8 @@ public class JdbcGtfsExporter {
             result.agency = export(Table.AGENCY);
             result.calendar = export(Table.CALENDAR);
             if (fromEditor) {
-                GTFSFeed feed = new GTFSFeed();
                 // Export schedule exceptions in place of calendar dates if exporting from the GTFS Editor.
+                GTFSFeed feed = new GTFSFeed();
                 // FIXME: The below table readers should probably just share a connection with the exporter.
                 JDBCTableReader<ScheduleException> exceptionsReader =
                         new JDBCTableReader(Table.SCHEDULE_EXCEPTIONS, dataSource, feedIdToExport + ".",
@@ -124,17 +124,22 @@ public class JdbcGtfsExporter {
             result.fareAttributes = export(Table.FARE_ATTRIBUTES);
             result.fareRules = export(Table.FARE_RULES);
             result.feedInfo = export(Table.FEED_INFO);
+            // FIXME: only write frequencies for "approved" routes using COPY TO with results of select query
             result.frequencies = export(Table.FREQUENCIES);
+            // FIXME: only write "approved" routes using COPY TO with results of select query
             result.routes = export(Table.ROUTES);
             // FIXME: Find some place to store errors encountered on export for patterns and pattern stops.
             // FIXME: Is there a need to export patterns or pattern stops? Should these be iterated over to ensure that
             // frequency-based pattern travel times match stop time arrivals/departures?
 //            export(Table.PATTERNS);
 //            export(Table.PATTERN_STOP);
+            // FIXME: only write shapes for "approved" routes using COPY TO with results of select query
             result.shapes = export(Table.SHAPES);
             result.stops = export(Table.STOPS);
+            // FIXME: only write stop times for "approved" routes using COPY TO with results of select query
             result.stopTimes = export(Table.STOP_TIMES);
             result.transfers = export(Table.TRANSFERS);
+            // FIXME: only write trips for "approved" routes using COPY TO with results of select query
             result.trips = export(Table.TRIPS);
 
             zipOutputStream.close();

--- a/src/main/java/com/conveyal/gtfs/loader/Table.java
+++ b/src/main/java/com/conveyal/gtfs/loader/Table.java
@@ -314,23 +314,23 @@ public class Table {
     }
 
 
-    public void createSqlTable(Connection connection) {
-        createSqlTable(connection, null, false, null);
+    public boolean createSqlTable(Connection connection) {
+        return createSqlTable(connection, null, false, null);
     }
 
-    public void createSqlTable(Connection connection, boolean makeIdSerial) {
-        createSqlTable(connection, null, makeIdSerial, null);
+    public boolean createSqlTable(Connection connection, boolean makeIdSerial) {
+        return createSqlTable(connection, null, makeIdSerial, null);
     }
 
-    public void createSqlTable(Connection connection, String namespace, boolean makeIdSerial) {
-        createSqlTable(connection, namespace, makeIdSerial, null);
+    public boolean createSqlTable(Connection connection, String namespace, boolean makeIdSerial) {
+        return createSqlTable(connection, namespace, makeIdSerial, null);
     }
 
     /**
      * Create an SQL table with all the fields specified by this table object,
      * plus an integer CSV line number field in the first position.
      */
-    public void createSqlTable (Connection connection, String namespace, boolean makeIdSerial, String[] primaryKeyFields) {
+    public boolean createSqlTable (Connection connection, String namespace, boolean makeIdSerial, String[] primaryKeyFields) {
         // Optionally join namespace and name to create full table name if namespace is not null (i.e., table object is
         // a spec table).
         String tableName = namespace != null ? String.join(".", namespace, name) : name;
@@ -349,7 +349,7 @@ public class Table {
             LOG.info(dropSql);
             statement.execute(dropSql);
             LOG.info(createSql);
-            statement.execute(createSql);
+            return statement.execute(createSql);
         } catch (Exception ex) {
             throw new StorageException(ex);
         }


### PR DESCRIPTION
### Stops for pattern and stops for route fields added to the GraphQL schema.
- This allows for fetching GTFS stop entities that are served by a pattern or a route nested underneath one of these entities.
### Adds blank snapshot functionality.
- This allows for the creation of a "blank" snapshot, i.e., the full set of tables required for GTFS editing with no rows.