### PR TITLE
Re-implement findPatterns method in MapDB GTFSFeed using storage-agnostic PatternFinder

### DIFF
--- a/src/main/java/com/conveyal/gtfs/GTFSFeed.java
+++ b/src/main/java/com/conveyal/gtfs/GTFSFeed.java
@@ -398,7 +398,11 @@ public class GTFSFeed implements Cloneable, Closeable {
     /**
      * MapDB-based implementation to find patterns.
      *
-     * FIXME: Remove and make pattern finding happen during validation?p
+     * FIXME: Remove and make pattern finding happen during validation? We want to share the pattern finder between the
+     * two implementations (MapDB and RDBMS), apply the same validation process to both kinds of storage, and produce
+     * Patterns in the same way in both cases, during validation. This prevents us from iterating over every stopTime
+     * twice, since we're already iterating over all of them in validation. However, in this case it might not be costly
+     * to simply retrieve the stop times from the stop_times map.
      */
     public void findPatterns () {
         PatternFinder patternFinder = new PatternFinder();

--- a/src/main/java/com/conveyal/gtfs/PatternFinder.java
+++ b/src/main/java/com/conveyal/gtfs/PatternFinder.java
@@ -63,7 +63,7 @@ public class PatternFinder {
 //
 //    }
 
-    public void processTrip(Trip trip, List<StopTime> orderedStopTimes) {
+    public void processTrip(Trip trip, Iterable<StopTime> orderedStopTimes) {
         if (++nTripsProcessed % 100000 == 0) {
             LOG.info("trip {}", human(nTripsProcessed));
         }
@@ -96,8 +96,9 @@ public class PatternFinder {
             // FIXME: Should associated shapes be a single entry?
             pattern.associatedShapes = new HashSet<>();
             trips.stream().forEach(trip -> pattern.associatedShapes.add(trip.shape_id));
-            if (pattern.associatedShapes.size() > 1) {
-                // Store an error if there is more than one shape per pattern.
+            if (pattern.associatedShapes.size() > 1 && errorStorage != null) {
+                // Store an error if there is more than one shape per pattern. Note: error storage is null if called via
+                // MapDB implementation.
                 // TODO: Should shape ID be added to trip pattern key?
                 errorStorage.storeError(NewGTFSError.forEntity(
                         pattern,

--- a/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
+++ b/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
@@ -219,7 +219,7 @@ public class JdbcTableWriter implements TableWriter {
                 continue;
             }
             JsonNode value = jsonObject.get(field.name);
-            LOG.info("{}={}", field.name, value);
+//            LOG.info("{}={}", field.name, value);
             try {
                 if (value == null || value.isNull()) {
                     if (field.isRequired()) {

--- a/src/main/java/com/conveyal/gtfs/model/Pattern.java
+++ b/src/main/java/com/conveyal/gtfs/model/Pattern.java
@@ -21,6 +21,11 @@ public class Pattern extends Entity {
     public static final long serialVersionUID = 1L;
     private static final Logger LOG = LoggerFactory.getLogger(Pattern.class);
 
+    @Override
+    public String getId () {
+        return pattern_id;
+    }
+
     // A unique ID for this journey pattern / stop pattern
     public String pattern_id;
 

--- a/src/main/java/com/conveyal/gtfs/validator/ServiceValidator.java
+++ b/src/main/java/com/conveyal/gtfs/validator/ServiceValidator.java
@@ -51,7 +51,7 @@ import java.util.Set;
  */
 public class ServiceValidator extends TripValidator {
 
-    private static final Logger LOG = LoggerFactory.getLogger(PatternFinderValidator.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ServiceValidator.class);
 
     private Map<String, ServiceInfo> serviceInfoForServiceId = new HashMap<>();
 


### PR DESCRIPTION
This fixes gtfs-lib for usage in r5.  The primary thing broken during the SQL load/edit enhancements was `GTFSFeed#findPatterns`, which was never re-implemented using the new `PatternFinder` class. This temporarily patches this so that r5 does not break when using the latest `gtfs-lib`.