### PR TITLE
Filter approved routes when exporting from GTFS editor

### DIFF
--- a/src/main/java/com/conveyal/gtfs/TripPatternKey.java
+++ b/src/main/java/com/conveyal/gtfs/TripPatternKey.java
@@ -36,7 +36,7 @@ public class TripPatternKey {
         dropoffTypes.add(st.drop_off_type);
         // Note, the items listed below are not used in the equality check.
         arrivalTimes.add(st.arrival_time);
-        departureTimes.add(st.departure_time - st.arrival_time);
+        departureTimes.add(st.departure_time);
         timepoints.add(st.timepoint);
         shapeDistances.add(st.shape_dist_traveled);
     }

--- a/src/main/java/com/conveyal/gtfs/loader/JdbcGtfsExporter.java
+++ b/src/main/java/com/conveyal/gtfs/loader/JdbcGtfsExporter.java
@@ -19,9 +19,18 @@ import java.io.FileOutputStream;
 import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.URI;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -40,7 +49,7 @@ public class JdbcGtfsExporter {
     private ZipOutputStream zipOutputStream;
     // The reference feed ID (namespace) to copy.
     private final String feedIdToExport;
-    private boolean postgresText;
+    private List<String> emptyTableList = new ArrayList<>();
 
     public JdbcGtfsExporter(String feedId, String outFile, DataSource dataSource, boolean fromEditor) {
         this.feedIdToExport = feedId;
@@ -68,16 +77,18 @@ public class JdbcGtfsExporter {
             // If we create a schema or table on one connection, then access it in a separate connection, we have no
             // guarantee that it exists when the accessing statement is executed.
             connection = dataSource.getConnection();
-            // Use the Postgres text load format if we're connected to that DBMS.
-            postgresText = connection.getMetaData().getDatabaseProductName().equals("PostgreSQL");
-            // Construct where clause for routes for use in filtering GTFS data if exporting from the editor.
-            String routesWhereClause = String.format(" where %s.%s.status = 2", feedIdToExport, Table.ROUTES.name);
+            if (!connection.getMetaData().getDatabaseProductName().equals("PostgreSQL")) {
+                // This code path currently requires the Postgres text "copy to" format.
+                throw new RuntimeException("Export from SQL database not implemented for non-PostgreSQL databases.");
+            }
+            // Construct where clause for routes table to filter only "approved" routes (and entities related to routes)
+            // if exporting a feed/schema that represents an editor snapshot.
+            String whereRouteIsApproved = String.format("where %s.%s.status = 2", feedIdToExport, Table.ROUTES.name);
             // Export each table in turn (by placing entry in zip output stream).
-            // FIXME: NO non-fatal exception errors are being captured during copy operations.
             result.agency = export(Table.AGENCY);
             result.calendar = export(Table.CALENDAR);
             if (fromEditor) {
-                // Export schedule exceptions in place of calendar dates if exporting from the GTFS Editor.
+                // Export schedule exceptions in place of calendar dates if exporting a feed/schema that represents an editor snapshot.
                 GTFSFeed feed = new GTFSFeed();
                 // FIXME: The below table readers should probably just share a connection with the exporter.
                 JDBCTableReader<ScheduleException> exceptionsReader =
@@ -87,6 +98,7 @@ public class JdbcGtfsExporter {
                         new JDBCTableReader(Table.CALENDAR, dataSource, feedIdToExport + ".",
                                 EntityPopulator.CALENDAR);
                 Iterable<Calendar> calendars = calendarsReader.getAll();
+                int calendarDateCount = 0;
                 for (Calendar cal : calendars) {
                     LOG.info("Iterating over calendar {}", cal.service_id);
                     Service service = new Service(cal.service_id);
@@ -114,12 +126,17 @@ public class JdbcGtfsExporter {
                                 throw new IllegalArgumentException("Duplicate schedule exceptions on " + date.toString());
 
                             service.calendar_dates.put(date, calendarDate);
+                            calendarDateCount += 1;
                         }
                     }
                     feed.services.put(cal.service_id, service);
                 }
-                LOG.info("Writing calendar dates from schedule exceptions");
-                new CalendarDate.Writer(feed).writeTable(zipOutputStream);
+                if (calendarDateCount == 0) {
+                    LOG.info("No calendar dates found. Skipping table.");
+                } else {
+                    LOG.info("Writing {} calendar dates from schedule exceptions", calendarDateCount);
+                    new CalendarDate.Writer(feed).writeTable(zipOutputStream);
+                }
             } else {
                 // Otherwise, simply export the calendar dates as they were loaded in.
                 result.calendarDates = export(Table.CALENDAR_DATES);
@@ -130,21 +147,23 @@ public class JdbcGtfsExporter {
             // Only write frequencies for "approved" routes using COPY TO with results of select query
             String frequencySelectSql = null;
             if (fromEditor) {
-                // Generate filter SQL for trips if exporting from the editor.
+                // Generate filter SQL for trips if exporting a feed/schema that represents an editor snapshot.
                 // The filter clause for frequencies requires two joins to reach the routes table and a where filter on
                 // route status.
-                frequencySelectSql = Table.FREQUENCIES.generateSelectSql(feedIdToExport, Requirement.OPTIONAL) +
-                        Table.FREQUENCIES.generateJoinSql(Table.TRIPS, feedIdToExport) +
-                        Table.TRIPS.generateJoinSql(Table.ROUTES, feedIdToExport, "route_id") +
-                        routesWhereClause;
+                frequencySelectSql = String.join(" ",
+                        Table.FREQUENCIES.generateSelectSql(feedIdToExport, Requirement.OPTIONAL),
+                        Table.FREQUENCIES.generateJoinSql(Table.TRIPS, feedIdToExport),
+                        Table.TRIPS.generateJoinSql(Table.ROUTES, feedIdToExport, "route_id", false),
+                        whereRouteIsApproved);
             }
             result.frequencies = export(Table.FREQUENCIES, frequencySelectSql);
             // Only write "approved" routes using COPY TO with results of select query
             String routeSelectSql = null;
             if (fromEditor) {
                 // The filter clause for routes is simple. We're just checking that the route is APPROVED.
-                routeSelectSql = Table.ROUTES.generateSelectSql(feedIdToExport, Requirement.OPTIONAL) +
-                        routesWhereClause;
+                routeSelectSql = String.join(" ",
+                        Table.ROUTES.generateSelectSql(feedIdToExport, Requirement.OPTIONAL),
+                        whereRouteIsApproved);
             }
             result.routes = export(Table.ROUTES, routeSelectSql);
             // FIXME: Find some place to store errors encountered on export for patterns and pattern stops.
@@ -155,47 +174,65 @@ public class JdbcGtfsExporter {
             // Only write shapes for "approved" routes using COPY TO with results of select query
             String shapeSelectSql = null;
             if (fromEditor) {
-                // Generate filter SQL for trips if exporting from the editor.
+                // Joined trips table needs to use a select distinct to ensure that multiple joins to the trips table
+                // don't appear in the result. This essentially grabs only one row from the trips table per unique
+                // shape_id, in effect creating a one-to-one mapping from a shape to a route. FIXME this is simplifying
+                // the relationship because multiple trips that share a single shape may operate on different routes.
+                String selectDistinct = String.format(
+                        // FIXME: I'm not sure if this is Postgres-specific syntax for SELECT DISTINCT
+                        "SELECT DISTINCT ON (shape_id) shape_id, trip_id, route_id from %s.%s",
+                        feedIdToExport, Table.TRIPS.name);
+                // Generate filter SQL for trips if exporting a feed/schema that represents an editor snapshot.
                 // The filter clause for shapes requires two joins to reach the routes table and a where filter on
                 // route status.
                 // FIXME: I'm not sure that shape_id is indexed for the trips table. This could cause slow downs.
-                shapeSelectSql = Table.SHAPES.generateSelectSql(feedIdToExport, Requirement.OPTIONAL) +
-                        Table.SHAPES.generateJoinSql(Table.TRIPS, feedIdToExport) +
-                        Table.TRIPS.generateJoinSql(Table.ROUTES, feedIdToExport, "route_id") +
-                        routesWhereClause;
+                shapeSelectSql = String.join(" ",
+                        Table.SHAPES.generateSelectSql(feedIdToExport, Requirement.OPTIONAL),
+                        Table.SHAPES.generateJoinSql(selectDistinct, Table.TRIPS, feedIdToExport),
+                        Table.TRIPS.generateJoinSql(Table.ROUTES, feedIdToExport, "route_id", false),
+                        whereRouteIsApproved);
             }
             result.shapes = export(Table.SHAPES, shapeSelectSql);
             result.stops = export(Table.STOPS);
             // Only write stop times for "approved" routes using COPY TO with results of select query
             String stopTimesSelectSql = null;
             if (fromEditor) {
-                // Generate filter SQL for trips if exporting from the editor.
+                // The select clause for stop_times requires transforming the time fields to the HH:MM:SS string format.
+                String selectWithTransformedTimes = Table.STOP_TIMES.generateSelectSql(feedIdToExport, Requirement.OPTIONAL)
+                        // FIXME This is postgres-specific and needs to be made generic for non-postgres databases.
+                        .replace("arrival_time", "TO_CHAR((arrival_time || ' second')::interval, 'HH24:MI:SS') as arrival_time")
+                        .replace("departure_time", "TO_CHAR((departure_time || ' second')::interval, 'HH24:MI:SS') as departure_time");
+                // Generate filter SQL for trips if exporting a feed/schema that represents an editor snapshot.
                 // The filter clause for stop times requires two joins to reach the routes table and a where filter on
                 // route status.
-                stopTimesSelectSql = Table.STOP_TIMES.generateSelectSql(feedIdToExport, Requirement.OPTIONAL) +
-                        Table.STOP_TIMES.generateJoinSql(Table.TRIPS, feedIdToExport) +
-                        Table.TRIPS.generateJoinSql(Table.ROUTES, feedIdToExport, "route_id") +
-                        routesWhereClause;
+                stopTimesSelectSql = String.join(" ",
+                        selectWithTransformedTimes,
+                        Table.STOP_TIMES.generateJoinSql(Table.TRIPS, feedIdToExport),
+                        Table.TRIPS.generateJoinSql(Table.ROUTES, feedIdToExport, "route_id", false),
+                        whereRouteIsApproved);
             }
             result.stopTimes = export(Table.STOP_TIMES, stopTimesSelectSql);
             result.transfers = export(Table.TRANSFERS);
             String tripSelectSql = null;
             if (fromEditor) {
-                // Generate filter SQL for trips if exporting from the editor.
+                // Generate filter SQL for trips if exporting a feed/schema that represents an editor snapshot.
                 // The filter clause for trips requires an inner join on the routes table and the same where check on
                 // route status.
-                tripSelectSql = Table.TRIPS.generateSelectSql(feedIdToExport, Requirement.OPTIONAL) +
-                        Table.TRIPS.generateJoinSql(Table.ROUTES, feedIdToExport, "route_id") +
-                        routesWhereClause;
+                tripSelectSql = String.join(" ",
+                        Table.TRIPS.generateSelectSql(feedIdToExport, Requirement.OPTIONAL),
+                        Table.TRIPS.generateJoinSql(Table.ROUTES, feedIdToExport, "route_id", false),
+                        whereRouteIsApproved);
             }
             result.trips = export(Table.TRIPS, tripSelectSql);
 
             zipOutputStream.close();
+            // Run clean up on the resulting zip file.
+            cleanUpZipFile();
             result.completionTime = System.currentTimeMillis();
             result.loadTimeMillis = result.completionTime - startTime;
             // Exporting primary GTFS tables for GRTA Xpress = 12 sec
             LOG.info("Exporting tables took {} sec", (result.loadTimeMillis) / 1000);
-            LOG.info(outFile);
+            LOG.info("Exported feed {} to zip file: {}", feedIdToExport, outFile);
         } catch (Exception ex) {
             // Note: Exceptions that occur during individual table loads are separately caught and stored in
             // TableLoadResult.
@@ -206,40 +243,73 @@ public class JdbcGtfsExporter {
         return result;
     }
 
+    /**
+     * Removes any empty zip files from the final zip file.
+     */
+    private void cleanUpZipFile() {
+        long startTime = System.currentTimeMillis();
+        // Define ZIP File System Properties in HashMap
+        Map<String, String> zip_properties = new HashMap<>();
+        // We want to read an existing ZIP File, so we set this to False
+        zip_properties.put("create", "false");
+
+        // Specify the path to the ZIP File that you want to read as a File System
+        URI zip_disk = URI.create("jar:file://" + outFile);
+
+        // Create ZIP file System
+        try (FileSystem fileSystem = FileSystems.newFileSystem(zip_disk, zip_properties)) {
+            // Get the Path inside ZIP File to delete the ZIP Entry
+            for (String fileName : emptyTableList) {
+                Path filePath = fileSystem.getPath(fileName);
+                // Execute Delete
+                Files.delete(filePath);
+                LOG.info("Empty file {} successfully deleted", fileName);
+            }
+        } catch (IOException e) {
+            LOG.error("Could not remove empty zip files");
+            e.printStackTrace();
+        }
+        LOG.info("Deleted {} empty files in {} ms", emptyTableList.size(), System.currentTimeMillis() - startTime);
+    }
+
     private TableLoadResult export (Table table) {
-        return export(table, null);
+        if (fromEditor) {
+            // Default behavior for exporting editor snapshot tables is to select only the spec fields.
+            return export(table, table.generateSelectSql(feedIdToExport, Requirement.OPTIONAL));
+        } else {
+            return export(table, null);
+        }
     }
 
     private TableLoadResult export (Table table, String filterSql) {
         long startTime = System.currentTimeMillis();
         TableLoadResult tableLoadResult = new TableLoadResult();
         try {
-            if (postgresText) {
-                // Create entry for table
-                ZipEntry zipEntry = new ZipEntry(table.name + ".txt");
-                zipOutputStream.putNextEntry(zipEntry);
+            // Create entry for table
+            String textFileName = table.name + ".txt";
+            ZipEntry zipEntry = new ZipEntry(textFileName);
+            zipOutputStream.putNextEntry(zipEntry);
 
-                // don't let CSVWriter close the stream when it is garbage-collected
-                OutputStream protectedOut = new FilterOutputStream(zipOutputStream);
-
-                if (filterSql == null) {
-                    // If there is no filter SQL specified, simply copy out the whole table.
-                    filterSql = String.format("%s.%s", feedIdToExport, table.name);
-                } else {
-                    // Surround filter SQL in parentheses.
-                    filterSql = String.format("(%s)", filterSql);
-                }
-                String copySql = String.format("copy %s to STDOUT DELIMITER ',' CSV HEADER", filterSql);
-                LOG.info(copySql);
-                // Our connection pool wraps the Connection objects, so we need to unwrap the Postgres connection interface.
-                CopyManager copyManager = new CopyManager(connection.unwrap(BaseConnection.class));
-                copyManager.copyOut(copySql, protectedOut);
-                zipOutputStream.closeEntry();
-                LOG.info("Copy {} completed in {} ms.", table.name, System.currentTimeMillis() - startTime);
+            // don't let CSVWriter close the stream when it is garbage-collected
+            OutputStream protectedOut = new FilterOutputStream(zipOutputStream);
+            if (filterSql == null) {
+                // If there is no filter SQL specified, simply copy out the whole table.
+                filterSql = String.format("%s.%s", feedIdToExport, table.name);
             } else {
-                LOG.error("Export not implemented for non-PostgreSQL databases.");
-                throw new NotImplementedException();
+                // Surround filter SQL in parentheses.
+                filterSql = String.format("(%s)", filterSql);
             }
+            String copySql = String.format("copy %s to STDOUT DELIMITER ',' CSV HEADER", filterSql);
+            LOG.info(copySql);
+            // Our connection pool wraps the Connection objects, so we need to unwrap the Postgres connection interface.
+            CopyManager copyManager = new CopyManager(connection.unwrap(BaseConnection.class));
+            tableLoadResult.rowCount = (int) copyManager.copyOut(copySql, protectedOut);
+            if (tableLoadResult.rowCount == 0) {
+                // If no rows were exported, keep track of table name for later removal.
+                emptyTableList.add(textFileName);
+            }
+            zipOutputStream.closeEntry();
+            LOG.info("Copied {} {} in {} ms.", tableLoadResult.rowCount, table.name, System.currentTimeMillis() - startTime);
             connection.commit();
         } catch (SQLException e) {
             // Rollback connection so that fatal exception does not impact loading of other tables.

--- a/src/main/java/com/conveyal/gtfs/loader/JdbcGtfsLoader.java
+++ b/src/main/java/com/conveyal/gtfs/loader/JdbcGtfsLoader.java
@@ -313,35 +313,34 @@ public class JdbcGtfsLoader {
         // TODO Strip out line returns, tabs in field contents.
         // By default the CSV reader trims leading and trailing whitespace in fields.
         // Build up a list of fields in the same order they appear in this GTFS CSV file.
-        Field[] rawFields = new Field[csvReader.getHeaderCount()];
+        Field[] fields = new Field[csvReader.getHeaderCount()];
         Set<String> fieldsSeen = new HashSet<>();
         String keyField = table.getKeyFieldName();
-        String orderField = table.getOrderFieldName();
         int keyFieldIndex = -1;
-        List<Integer> columnsToSkip = new ArrayList<>();
         for (int h = 0; h < csvReader.getHeaderCount(); h++) {
             String header = sanitize(csvReader.getHeader(h));
             if (fieldsSeen.contains(header) || "id".equals(header)) {
                 // FIXME: add separate error for tables containing ID field.
                 errorStorage.storeError(NewGTFSError.forTable(table, DUPLICATE_HEADER).setBadValue(header));
-                rawFields[h] = null;
-                // Store column index to skip when populating values below.
-                columnsToSkip.add(h);
+                fields[h] = null;
             } else {
-                rawFields[h] = table.getFieldForName(header);
+                fields[h] = table.getFieldForName(header);
                 fieldsSeen.add(header);
                 if (keyField.equals(header)) {
                     keyFieldIndex = h;
                 }
             }
         }
-        Collections.sort(columnsToSkip, Collections.reverseOrder());
-        // Replace fields array with filtered list that does not include null values (for duplicate headers or ID field).
-        Field[] fields = Arrays.stream(rawFields).filter(field -> field != null).toArray(Field[]::new);
-
+        // Create separate fields array with filtered list that does not include null values (for duplicate headers or
+        // ID field). This is solely used to construct the table and array of values to load.
+        Field[] cleanFields = Arrays.stream(fields).filter(field -> field != null).toArray(Field[]::new);
+        if (cleanFields.length == 0) {
+            // Do not create the table if there are no valid fields.
+            return 0;
+        }
         // Replace the GTFS spec Table with one representing the SQL table we will populate, with reordered columns.
         // FIXME this is confusing, we only create a new table object so we can call a couple of methods on it, all of which just need a list of fields.
-        Table targetTable = new Table(tablePrefix + table.name, table.entityClass, table.required, fields);
+        Table targetTable = new Table(tablePrefix + table.name, table.entityClass, table.required, cleanFields);
 
         // NOTE H2 doesn't seem to work with schemas (or create schema doesn't work).
         // With bulk loads it takes 140 seconds to load the data and additional 120 seconds just to index the stop times.
@@ -363,7 +362,7 @@ public class JdbcGtfsLoader {
 
         // When outputting text, accumulate transformed strings to allow skipping rows when errors are encountered.
         // One extra position in the array for the CSV line number.
-        String[] transformedStrings = new String[fields.length + 1];
+        String[] transformedStrings = new String[cleanFields.length + 1];
 
         // Iterate over each record and prepare the record for storage in the table either through batch insert
         // statements or postgres text copy operation.
@@ -376,8 +375,8 @@ public class JdbcGtfsLoader {
             }
             int lineNumber = ((int) csvReader.getCurrentRecord()) + 2;
             if (lineNumber % 500_000 == 0) LOG.info("Processed {}", human(lineNumber));
-            if (csvReader.getColumnCount() != rawFields.length) {
-                String badValues = String.format("expected=%d; found=%d", rawFields.length, csvReader.getColumnCount());
+            if (csvReader.getColumnCount() != fields.length) {
+                String badValues = String.format("expected=%d; found=%d", fields.length, csvReader.getColumnCount());
                 errorStorage.storeError(NewGTFSError.forLine(table, lineNumber, WRONG_NUMBER_OF_FIELDS, badValues));
                 continue;
             }
@@ -386,20 +385,21 @@ public class JdbcGtfsLoader {
             // The first field holds the line number of the CSV file. Prepared statement parameters are one-based.
             if (postgresText) transformedStrings[0] = Integer.toString(lineNumber);
             else insertStatement.setInt(1, lineNumber);
-
-            // Remove the values from the csv row for any bad fields (i.e., duplicate headers or named "ID").
-            // CSV values needs to be a LinkedList to support removal operation (Arrays.asList is read-only).
-            List<String> values = new LinkedList<>(Arrays.asList(csvReader.getValues()));
-            for (int columnIndex : columnsToSkip) {
-                values.remove(columnIndex);
-            }
+            // Maintain a separate columnIndex from for loop because some fields may be null and not included in the set
+            // of fields for this table.
+            int columnIndex = 0;
             for (int f = 0; f < fields.length; f++) {
                 Field field = fields[f];
-                String string = values.get(f);
+                // If the field is null, it represents a duplicate header or ID field and must be skipped to maintain
+                // table integrity.
+                if (field == null) continue;
+                String string = csvReader.get(f);
                 // Use spec table to check that references are valid and IDs are unique.
                 table.checkReferencesAndUniqueness(keyValue, lineNumber, field, string, referenceTracker);
                 // Add value for entry into table
-                setValueForField(table, f, lineNumber, field, string, postgresText, transformedStrings);
+                setValueForField(table, columnIndex, lineNumber, field, string, postgresText, transformedStrings);
+                // Increment column index.
+                columnIndex += 1;
             }
             if (postgresText) {
                 // Print a new line in the standard postgres text format:

--- a/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
+++ b/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
@@ -206,7 +206,7 @@ public class JdbcTableWriter implements TableWriter {
         // JDBC SQL statements use a one-based index for setting fields/parameters
         List<String> missingFieldNames = new ArrayList<>();
         int index = 1;
-        for (Field field : table.fieldsForEditor()) {
+        for (Field field : table.editorFields()) {
             if (!jsonObject.has(field.name)) {
                 // If there is a field missing from the JSON string and it is required to write to an editor table,
                 // throw an exception (handled after the fields iteration. In an effort to keep the database integrity
@@ -614,7 +614,7 @@ public class JdbcTableWriter implements TableWriter {
         for (Table referencingTable : referencingTables) {
             // Update/delete foreign references that have match the key value.
             String refTableName = String.join(".", namespace, referencingTable.name);
-            for (Field field : referencingTable.fieldsForEditor()) {
+            for (Field field : referencingTable.editorFields()) {
                 if (field.isForeignReference() && field.referenceTable.name.equals(table.name)) {
                     // Get unique IDs before delete (for logging/message purposes).
                     // TIntSet uniqueIds = getIdsForCondition(refTableName, keyField, keyValue, connection);

--- a/src/main/java/com/conveyal/gtfs/loader/Requirement.java
+++ b/src/main/java/com/conveyal/gtfs/loader/Requirement.java
@@ -1,7 +1,13 @@
 package com.conveyal.gtfs.loader;
 
 /**
- * Created by abyrd on 2017-03-30
+ * These are field requirement levels, which should be assigned accordingly to any fields within a {@link Table}
+ * to determine if a field is requisite for a specific purpose.
+ *
+ * TODO: These enum values should be placed in an ordered list or assigned order constants, which allow a generic
+ * filtering predicate that returns true for elements "up to and including" a supplied level. Currently, this has a
+ * fragmented implementation in {@link Table#editorFields()} and {@link Table#specFields()}. However, it is currently
+ * unclear what the levels.order for the types EXTENSION, PROPIETARY, and UNKNOWN ought to be.
  */
 public enum Requirement {
     REQUIRED,    // Required by the GTFS spec

--- a/src/main/java/com/conveyal/gtfs/loader/Table.java
+++ b/src/main/java/com/conveyal/gtfs/loader/Table.java
@@ -29,8 +29,6 @@ import static com.conveyal.gtfs.loader.Requirement.*;
 public class Table {
 
     private static final Logger LOG = LoggerFactory.getLogger(Table.class);
-    private static final Requirement[] requirementsForEditorFields = new Requirement[]{EDITOR, REQUIRED, OPTIONAL};
-    private static final Requirement[] requirementsForSpecFields = new Requirement[]{REQUIRED, OPTIONAL};
 
     public final String name;
 
@@ -304,25 +302,35 @@ public class Table {
         return this;
     }
 
+    /**
+     * Get only those fields included in the official GTFS specification for this table or used by the editor.
+     */
     public List<Field> editorFields() {
-        // Filter out fields not used in editor (i.e., extension fields).
-        return Arrays.stream(fields)
-                .filter(field -> Arrays.asList(requirementsForEditorFields).indexOf(field.requirement) != -1)
-                .collect(Collectors.toList());
+        List<Field> editorFields = new ArrayList<>();
+        for (Field f : fields) if (f.requirement == REQUIRED || f.requirement == OPTIONAL || f.requirement == EDITOR) {
+            editorFields.add(f);
+        }
+        return editorFields;
     }
 
+    /**
+     * Get only those fields marked as required in the official GTFS specification for this table.
+     */
     public List<Field> requiredFields () {
         // Filter out fields not used in editor (i.e., extension fields).
-        return Arrays.stream(fields)
-                .filter(field -> REQUIRED == field.requirement)
-                .collect(Collectors.toList());
+        List<Field> requiredFields = new ArrayList<>();
+        for (Field f : fields) if (f.requirement == REQUIRED) requiredFields.add(f);
+        return requiredFields;
     }
 
+    /**
+     * Get only those fields included in the official GTFS specification for this table, i.e., filter out fields used
+     * in the editor or extensions.
+     */
     public List<Field> specFields () {
-        // Filter out fields not used in editor (i.e., extension fields).
-        return Arrays.stream(fields)
-                .filter(field -> Arrays.asList(requirementsForSpecFields).indexOf(field.requirement) != -1)
-                .collect(Collectors.toList());
+        List<Field> specFields = new ArrayList<>();
+        for (Field f : fields) if (f.requirement == REQUIRED || f.requirement == OPTIONAL) specFields.add(f);
+        return specFields;
     }
 
     public boolean isCascadeDeleteRestricted() {
@@ -387,20 +395,25 @@ public class Table {
      * Create SQL string for use in insert statement. Note, this filters table's fields to only those used in editor.
      */
     public String generateInsertSql (String namespace, boolean setDefaultId) {
-        String tableName = namespace == null ? name : String.join(".", namespace, name);
+        String tableName = namespace == null
+                ? name
+                : String.join(".", namespace, name);
         String questionMarks = String.join(", ", Collections.nCopies(editorFields().size(), "?"));
-        String joinedFieldNames = fieldsToString(editorFields());
+        String joinedFieldNames = commaSeparatedNames(editorFields());
         String idValue = setDefaultId ? "DEFAULT" : "?";
         return String.format("insert into %s (id, %s) values (%s, %s)", tableName, joinedFieldNames, idValue, questionMarks);
     }
 
-    public static String fieldsToString (List<Field> fieldsToJoin) {
-        return fieldsToString(fieldsToJoin, null);
+    public String commaSeparatedNames(List<Field> fieldsToJoin) {
+        return commaSeparatedNames(fieldsToJoin, null);
     }
 
-    public static String fieldsToString (List<Field> fieldsToJoin, String prefix) {
+    public String commaSeparatedNames(List<Field> fieldsToJoin, String prefix) {
         return fieldsToJoin.stream()
-                .map(f -> prefix != null ? prefix + f.name : f.name)
+                // Only prefix fields that are foreign refs or key fields
+                .map(f -> prefix != null && (f.isForeignReference() || getKeyFieldName().equals(f.name))
+                        ? prefix + f.name
+                        : f.name)
                 .collect(Collectors.joining(", "));
     }
 
@@ -434,40 +447,70 @@ public class Table {
     public String generateSelectSql (String namespace, Requirement minimumRequirement) {
         String fieldsString;
         String tableName = String.join(".", namespace, name);
-        if (minimumRequirement.equals(EDITOR)) fieldsString = fieldsToString(editorFields(), tableName + ".");
-        else if (minimumRequirement.equals(OPTIONAL)) fieldsString = fieldsToString(specFields(), tableName + ".");
-        else if (minimumRequirement.equals(REQUIRED)) fieldsString = fieldsToString(requiredFields(), tableName + ".");
+        String fieldPrefix = tableName + ".";
+        if (minimumRequirement.equals(EDITOR)) fieldsString = commaSeparatedNames(editorFields(), fieldPrefix);
+        else if (minimumRequirement.equals(OPTIONAL)) fieldsString = commaSeparatedNames(specFields(), fieldPrefix);
+        else if (minimumRequirement.equals(REQUIRED)) fieldsString = commaSeparatedNames(requiredFields(), fieldPrefix);
         else fieldsString = "*";
         return String.format("select %s from %s", fieldsString, tableName);
+    }
+
+    public String generateJoinSql (Table joinTable, String namespace, String fieldName, boolean prefixTableName) {
+        return generateJoinSql(null, joinTable, null, namespace, fieldName, prefixTableName);
+    }
+
+    public String generateJoinSql (String optionalSelect, Table joinTable, String namespace) {
+        return generateJoinSql(optionalSelect, joinTable, null, namespace, null, true);
+    }
+
+    public String generateJoinSql (Table joinTable, String namespace) {
+        return generateJoinSql(null, joinTable, null, namespace, null, true);
     }
 
     /**
      * Constructs a join clause to use in conjunction with {@link #generateJoinSql}. By default the join type is "INNER
      * JOIN" and the join field is whatever the table instance's key field is. Both of those defaults can be overridden
      * with the other overloaded methods.
+     * @param optionalSelect optional select query to pre-select the join table
+     * @param joinTable the Table to join with
+     * @param joinType type of join (e.g., INNER JOIN, OUTER LEFT JOIN, etc.)
+     * @param namespace feedId (or schema prefix)
+     * @param fieldName the field to join on (default's to key field)
+     * @param prefixTableName whether to prefix this table's name with the schema (helpful if this join follows a
+     *                        previous join that renamed the table by dropping the schema/namespace
+     * @return a fully formed join clause that can be appended to a select statement
      */
-    public String generateJoinSql (Table joinTable, String namespace) {
-        return generateJoinSql(joinTable, null, namespace, null);
-    }
-
-    public String generateJoinSql (Table joinTable, String namespace, String fieldName) {
-        return generateJoinSql(joinTable, null, namespace, fieldName);
-    }
-
-    public String generateJoinSql (Table joinTable, String joinType, String namespace, String fieldName) {
+    public String generateJoinSql (String optionalSelect, Table joinTable, String joinType, String namespace, String fieldName, boolean prefixTableName) {
         if (fieldName == null) {
+            // Default to key field if field name is not specified
             fieldName = getKeyFieldName();
         }
         if (joinType == null) {
+            // Default to INNER JOIN if no join type provided
             joinType = "INNER JOIN";
         }
+        String joinTableQuery;
+        String joinTableName;
+        if (optionalSelect != null) {
+            // If a pre-select query is provided for the join table, the join table name must not contain the namespace
+            // prefix.
+            joinTableName = joinTable.name;
+            joinTableQuery = String.format("(%s) %s", optionalSelect, joinTableName);
+        } else {
+            // Otherwise, set both the join "query" and the table name to the standard "namespace.table_name"
+            joinTableQuery = joinTableName = String.format("%s.%s", namespace, joinTable.name);
+        }
+        // If prefix table name is set to false, skip prefixing the table name.
+        String tableName = prefixTableName ? String.format("%s.%s", namespace, this.name) :this.name;
         // Construct the join clause. A sample might appear like:
-        // " INNER JOIN schema.join_table ON schema.this_table.field_name = schema.join_table.field_name"
-        return String.format(" %s %s.%s ON %s.%s.%s = %s.%s.%s ",
+        // "INNER JOIN schema.join_table ON schema.this_table.field_name = schema.join_table.field_name"
+        // OR if optionalSelect is specified
+        // "INNER JOIN (select * from schema.join_table where x = 'y') join_table ON schema.this_table.field_name = join_table.field_name"
+        return String.format("%s %s ON %s.%s = %s.%s",
                 joinType,
-                namespace, joinTable.name,
-                namespace, this.name, fieldName,
-                namespace, joinTable.name, fieldName);
+                joinTableQuery,
+                tableName, fieldName,
+                joinTableName, fieldName);
     }
 
     public String generateDeleteSql (String namespace) {

--- a/src/main/java/com/conveyal/gtfs/validator/PatternFinderValidator.java
+++ b/src/main/java/com/conveyal/gtfs/validator/PatternFinderValidator.java
@@ -102,7 +102,8 @@ public class PatternFinderValidator extends TripValidator {
                 insertPatternStatement.setString(2, pattern.route_id);
                 insertPatternStatement.setString(3, pattern.name);
                 // FIXME: This could be null...
-                insertPatternStatement.setString(4, pattern.associatedShapes.iterator().next());
+                String shapeId = pattern.associatedShapes.iterator().next();
+                insertPatternStatement.setString(4, shapeId);
                 insertPatternStatement.addBatch();
                 // Construct pattern stops based on values in trip pattern key.
                 // FIXME: Use pattern stops table here?
@@ -110,12 +111,13 @@ public class PatternFinderValidator extends TripValidator {
                     int travelTime = 0;
                     String stopId = key.stops.get(i);
                     if (i > 0) travelTime = key.arrivalTimes.get(i) - key.departureTimes.get(i - 1);
+                    int dwellTime = key.departureTimes.get(i) - key.arrivalTimes.get(i);
 
                     insertPatternStopStatement.setString(1, pattern.pattern_id);
                     setIntParameter(insertPatternStopStatement, 2, i);
                     insertPatternStopStatement.setString(3, stopId);
                     setIntParameter(insertPatternStopStatement,4, travelTime);
-                    setIntParameter(insertPatternStopStatement,5, key.departureTimes.get(i) - key.arrivalTimes.get(i));
+                    setIntParameter(insertPatternStopStatement,5, dwellTime);
                     setIntParameter(insertPatternStopStatement,6, key.dropoffTypes.get(i));
                     // FIXME: NPE encountered on setIntParameter for key pickup_types?
                     setIntParameter(insertPatternStopStatement,7, key.pickupTypes.get(i));


### PR DESCRIPTION
This PR adds the GTFS editor feature that filters out un-approved routes when exporting a snapshot to GTFS.  This is achieved by embedding filtering select statements into the `COPY TO` SQL.  These filters select only those routes with `status = 2` (i.e., route is approved) and joins this selection of routes to related tables (specifically, trips, stop_times, and shapes).

It also addresses a bug where duplicate row headers or headers named `id` cause a table load failure.