### PR TITLE
Allow null agency_id; fix calendar_dates false duplicate service_id

### DIFF
--- a/src/main/java/com/conveyal/gtfs/loader/EntityPopulator.java
+++ b/src/main/java/com/conveyal/gtfs/loader/EntityPopulator.java
@@ -255,8 +255,11 @@ public interface EntityPopulator<T> {
     static int getIntIfPresent (ResultSet resultSet, String columnName,
                                        TObjectIntMap<String> columnForName) throws SQLException {
         int columnIndex = columnForName.get(columnName);
-        // FIXME: if SQL value is null, resultSet.getInt will return 0. Should INT_MISSING do the same?
         if (columnIndex == 0) return Entity.INT_MISSING;
-        else return resultSet.getInt(columnIndex);
+        int intValue = resultSet.getInt(columnIndex);
+        // If SQL value for column was null, resultSet.getInt will return 0. If this is the case, override value with
+        // INT_MISSING.
+        if (resultSet.wasNull()) return Entity.INT_MISSING;
+        else return intValue;
     }
 }

--- a/src/main/java/com/conveyal/gtfs/loader/Field.java
+++ b/src/main/java/com/conveyal/gtfs/loader/Field.java
@@ -28,6 +28,7 @@ public abstract class Field {
      * */
     Table referenceTable = null;
     private boolean shouldBeIndexed;
+    private boolean emptyValuePermitted;
 
     public Field(String name, Requirement requirement) {
         this.name = name;
@@ -106,10 +107,27 @@ public abstract class Field {
     /**
      * Fluent method indicates that this field is a reference to an entry in the table provided as an argument.
      * @param table
-     * @return
+     * @return this same Field instance
      */
     public Field isReferenceTo(Table table) {
         this.referenceTable = table;
         return this;
+    }
+
+    /**
+     * Fluent method to permit empty values for this field. Used for cases like fare_attributes#transfers, where empty
+     * values are OK on a required field.
+     * @return this same Field instance, which allows constructing and assigning the instance in the same statement.
+     */
+    public Field permitEmptyValue () {
+        this.emptyValuePermitted = true;
+        return this;
+    }
+
+    /**
+     * Check if empty values are permitted for this field.
+     */
+    public boolean isEmptyValuePermitted() {
+        return this.emptyValuePermitted;
     }
 }

--- a/src/main/java/com/conveyal/gtfs/loader/JdbcGtfsLoader.java
+++ b/src/main/java/com/conveyal/gtfs/loader/JdbcGtfsLoader.java
@@ -393,6 +393,7 @@ public class JdbcGtfsLoader {
                 // If the field is null, it represents a duplicate header or ID field and must be skipped to maintain
                 // table integrity.
                 if (field == null) continue;
+                // CSV reader get on an empty field will be an empty string literal.
                 String string = csvReader.get(f);
                 // Use spec table to check that references are valid and IDs are unique.
                 table.checkReferencesAndUniqueness(keyValue, lineNumber, field, string, referenceTracker);
@@ -455,7 +456,7 @@ public class JdbcGtfsLoader {
     public void setValueForField(Table table, int fieldIndex, int lineNumber, Field field, String string, boolean postgresText, String[] transformedStrings) {
         if (string.isEmpty()) {
             // CSV reader always returns empty strings, not nulls
-            if (field.isRequired() && errorStorage != null) {
+            if (field.isRequired() && !field.isEmptyValuePermitted() && errorStorage != null) {
                 errorStorage.storeError(NewGTFSError.forLine(table, lineNumber, MISSING_FIELD, field.name));
             }
             setFieldToNull(postgresText, transformedStrings, fieldIndex, field);

--- a/src/main/java/com/conveyal/gtfs/loader/Table.java
+++ b/src/main/java/com/conveyal/gtfs/loader/Table.java
@@ -100,7 +100,7 @@ public class Table {
         new DoubleField("price", REQUIRED, 0.0, Double.MAX_VALUE),
         new CurrencyField("currency_type", REQUIRED),
         new ShortField("payment_method", REQUIRED, 1),
-        new ShortField("transfers", REQUIRED, 2),
+        new ShortField("transfers", REQUIRED, 2).permitEmptyValue(),
         new IntegerField("transfer_duration", OPTIONAL)
     ).addPrimaryKey();
 

--- a/src/main/java/com/conveyal/gtfs/validator/ServiceValidator.java
+++ b/src/main/java/com/conveyal/gtfs/validator/ServiceValidator.java
@@ -77,8 +77,10 @@ public class ServiceValidator extends TripValidator {
         // Get the map from modes to service durations in seconds for this trip's service ID.
         // Create a new empty map if it doesn't yet exist.
         ServiceInfo serviceInfo = serviceInfoForServiceId.computeIfAbsent(trip.service_id, ServiceInfo::new);
-        // Increment the service duration for this trip's transport mode and service ID.
-        serviceInfo.durationByRouteType.adjustOrPutValue(route.route_type, tripDurationSeconds, tripDurationSeconds);
+        if (route != null) {
+            // Increment the service duration for this trip's transport mode and service ID.
+            serviceInfo.durationByRouteType.adjustOrPutValue(route.route_type, tripDurationSeconds, tripDurationSeconds);
+        }
         // Record which trips occur on each service_id.
         serviceInfo.tripIds.add(trip.trip_id);
         // TODO validate mode codes


### PR DESCRIPTION
This fixes the following:
- [Per the GTFS spec](https://developers.google.com/transit/gtfs/reference/#agencytxt), agency ID can be empty if there is only one agency in the feed.  This fix allows this empty value when editing agencies iff there is one agency.
- Multiple calendar_dates rows with the same `service_id` value should not cause duplicate ID errors to be recorded.
- Allow empty `transfers` field fare_attributes table
- Handle null ints when filling values in `EntityPopluator`