### PR TITLE
Add bounding box and string search GraphQL queries; Reconcile stop times to pattern stop changes

### DIFF
--- a/src/main/java/com/conveyal/gtfs/graphql/GraphQLGtfsSchema.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/GraphQLGtfsSchema.java
@@ -255,12 +255,12 @@ public class GraphQLGtfsSchema {
             .field(MapFetcher.field("route_desc"))
             .field(MapFetcher.field("route_url"))
             .field(MapFetcher.field("route_branding_url"))
-            .field(MapFetcher.field("wheelchair_boarding"))
             // TODO route_type as enum or int
             .field(MapFetcher.field("route_type"))
             .field(MapFetcher.field("route_color"))
             .field(MapFetcher.field("route_text_color"))
             // FIXME ˇˇ Editor fields that should perhaps be moved elsewhere.
+            .field(MapFetcher.field("wheelchair_accessible"))
             .field(MapFetcher.field("publicly_visible", GraphQLInt))
             .field(MapFetcher.field("status", GraphQLInt))
             // FIXME ^^

--- a/src/main/java/com/conveyal/gtfs/graphql/GraphQLGtfsSchema.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/GraphQLGtfsSchema.java
@@ -18,6 +18,7 @@ import graphql.schema.GraphQLTypeReference;
 import java.sql.Array;
 import java.sql.SQLException;
 
+import static com.conveyal.gtfs.graphql.GraphQLUtil.floatArg;
 import static com.conveyal.gtfs.graphql.GraphQLUtil.intArg;
 import static com.conveyal.gtfs.graphql.GraphQLUtil.intt;
 import static com.conveyal.gtfs.graphql.GraphQLUtil.multiStringArg;
@@ -633,6 +634,10 @@ public class GraphQLGtfsSchema {
                     .argument(stringArg("namespace")) // FIXME maybe these nested namespace arguments are not doing anything.
                     .argument(multiStringArg("stop_id"))
                     .argument(multiStringArg("pattern_id"))
+                    .argument(floatArg("minLat"))
+                    .argument(floatArg("minLon"))
+                    .argument(floatArg("maxLat"))
+                    .argument(floatArg("maxLon"))
                     .argument(intArg(ID_ARG))
                     .argument(intArg(LIMIT_ARG))
                     .argument(intArg(OFFSET_ARG))

--- a/src/main/java/com/conveyal/gtfs/graphql/GraphQLUtil.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/GraphQLUtil.java
@@ -5,6 +5,7 @@ import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLList;
 
+import static graphql.Scalars.GraphQLFloat;
 import static graphql.Scalars.GraphQLInt;
 import static graphql.Scalars.GraphQLString;
 import static graphql.schema.GraphQLArgument.newArgument;
@@ -46,6 +47,13 @@ public class GraphQLUtil {
         return newArgument()
                 .name(name)
                 .type(GraphQLInt)
+                .build();
+    }
+
+    public static GraphQLArgument floatArg (String name) {
+        return newArgument()
+                .name(name)
+                .type(GraphQLFloat)
                 .build();
     }
 

--- a/src/main/java/com/conveyal/gtfs/loader/DateField.java
+++ b/src/main/java/com/conveyal/gtfs/loader/DateField.java
@@ -56,7 +56,7 @@ public class DateField extends Field {
      */
     public void setParameter (PreparedStatement preparedStatement, int oneBasedIndex, LocalDate localDate) {
         try {
-            if (localDate == null) preparedStatement.setNull(oneBasedIndex, getSqlType().getVendorTypeNumber());
+            if (localDate == null) setNull(preparedStatement, oneBasedIndex);
             else preparedStatement.setString(oneBasedIndex, localDate.format(GTFS_DATE_FORMATTER));
         } catch (Exception e) {
             throw new StorageException(e);

--- a/src/main/java/com/conveyal/gtfs/loader/EntityPopulator.java
+++ b/src/main/java/com/conveyal/gtfs/loader/EntityPopulator.java
@@ -4,6 +4,7 @@ import com.conveyal.gtfs.model.Agency;
 import com.conveyal.gtfs.model.Calendar;
 import com.conveyal.gtfs.model.CalendarDate;
 import com.conveyal.gtfs.model.Entity;
+import com.conveyal.gtfs.model.PatternStop;
 import com.conveyal.gtfs.model.Route;
 import com.conveyal.gtfs.model.ScheduleException;
 import com.conveyal.gtfs.model.ScheduleException.ExemplarServiceDescriptor;
@@ -52,6 +53,19 @@ import static com.conveyal.gtfs.model.ScheduleException.exemplarFromInt;
  */
 public interface EntityPopulator<T> {
     Logger LOG = LoggerFactory.getLogger(EntityPopulator.class);
+    EntityPopulator<PatternStop> PATTERN_STOP = (result, columnForName) -> {
+        PatternStop patternStop = new PatternStop();
+        patternStop.stop_id = getStringIfPresent(result, "stop_id", columnForName);
+        patternStop.default_dwell_time = getIntIfPresent(result, "default_dwell_time", columnForName);
+        patternStop.default_travel_time = getIntIfPresent(result, "default_travel_time", columnForName);
+        patternStop.pattern_id = getStringIfPresent(result, "pattern_id", columnForName);
+        patternStop.drop_off_type = getIntIfPresent(result, "drop_off_type", columnForName);
+        patternStop.pickup_type = getIntIfPresent(result, "pickup_type", columnForName);
+        patternStop.stop_sequence = getIntIfPresent(result, "stop_sequence", columnForName);
+        patternStop.timepoint = getIntIfPresent(result, "timepoint", columnForName);
+        patternStop.shape_dist_traveled = getDoubleIfPresent(result, "shape_dist_traveled", columnForName);
+        return patternStop;
+    };
 
     T populate (ResultSet results, TObjectIntMap<String> columnForName) throws SQLException;
 

--- a/src/main/java/com/conveyal/gtfs/loader/Field.java
+++ b/src/main/java/com/conveyal/gtfs/loader/Field.java
@@ -1,6 +1,7 @@
 package com.conveyal.gtfs.loader;
 
 import java.sql.PreparedStatement;
+import java.sql.SQLException;
 import java.sql.SQLType;
 
 /**
@@ -46,6 +47,10 @@ public abstract class Field {
 
     public abstract void setParameter(PreparedStatement preparedStatement, int oneBasedIndex, String string);
 
+    public void setNull(PreparedStatement preparedStatement, int oneBasedIndex) throws SQLException {
+        preparedStatement.setNull(oneBasedIndex, getSqlType().getVendorTypeNumber());
+    }
+
     public abstract SQLType getSqlType ();
 
     // Overridden to create exception for "double precision", since its enum value is just called DOUBLE, and ARRAY types,
@@ -86,6 +91,11 @@ public abstract class Field {
         return this.requirement == Requirement.REQUIRED;
     }
 
+    /**
+     * More than one foreign reference should not be created on the same table to the same foreign table. This is what
+     * allows us to embed updates to a sub-table in nested JSON because this creates a many-to-one reference instead of
+     * a many-to-many reference.
+     */
     public boolean isForeignReference () {
         return this.referenceTable != null;
     }

--- a/src/main/java/com/conveyal/gtfs/loader/JdbcGTFSFeedConverter.java
+++ b/src/main/java/com/conveyal/gtfs/loader/JdbcGTFSFeedConverter.java
@@ -189,7 +189,7 @@ public class JdbcGTFSFeedConverter {
             // FIXME: will this throw an NPE if feedId or feedVersion are empty?
             insertStatement.setString(4, feedId.isEmpty() ? null : feedId);
             insertStatement.setString(5, feedVersion.isEmpty() ? null : feedVersion);
-            insertStatement.setString(6, "mapdb_gtfs_feed"); // snapshotOf
+            insertStatement.setString(6, "mapdb_gtfs_feed"); // filename
             insertStatement.execute();
             connection.commit();
             LOG.info("Created new feed namespace: {}", insertStatement);

--- a/src/main/java/com/conveyal/gtfs/loader/JdbcGtfsLoader.java
+++ b/src/main/java/com/conveyal/gtfs/loader/JdbcGtfsLoader.java
@@ -491,7 +491,7 @@ public class JdbcGtfsLoader {
             // Adjust parameter index by two: indexes are one-based and the first one is the CSV line number.
         else try {
             //            LOG.info("setting {} index to null", fieldIndex + 2);
-            insertStatement.setNull(fieldIndex + 2, field.getSqlType().getVendorTypeNumber());
+            field.setNull(insertStatement, fieldIndex + 2);
         } catch (SQLException e) {
             e.printStackTrace();
             // FIXME: store error here? It appears that an exception should only be thrown if the type value is invalid,

--- a/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
+++ b/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
@@ -210,8 +210,10 @@ public class JdbcTableWriter implements TableWriter {
         int oneBasedIndex = 1;
         // Iterate over list of fields that need to be updated and set params.
         for (int i = 0; i < fields.size(); i++) {
+            Field field = fields.get(i);
             String newValue = values.get(i).isNull() ? null : values.get(i).asText();
-            fields.get(i).setParameter(statement, oneBasedIndex++, newValue);
+            if (newValue == null) field.setNull(statement, oneBasedIndex++);
+            else field.setParameter(statement, oneBasedIndex++, newValue);
         }
         // Set "where clause" with value for key field (e.g., set values where pattern_id = '3')
         statement.setString(oneBasedIndex++, jsonObject.get(keyField).asText());
@@ -280,7 +282,7 @@ public class JdbcTableWriter implements TableWriter {
                         continue;
                     }
                     // Handle setting null value on statement
-                    preparedStatement.setNull(index, field.getSqlType().getVendorTypeNumber());
+                    field.setNull(preparedStatement, index);
                 } else {
                     List<String> values = new ArrayList<>();
                     if (value.isArray()) {
@@ -303,7 +305,7 @@ public class JdbcTableWriter implements TableWriter {
                                 missingFieldNames.add(field.name);
                                 continue;
                             }
-                            preparedStatement.setNull(index, field.getSqlType().getVendorTypeNumber());
+                            field.setNull(preparedStatement, index);
                         } else {
                             // Try to parse integer seconds value
                             preparedStatement.setInt(index, Integer.parseInt(value.asText()));

--- a/src/main/java/com/conveyal/gtfs/loader/Table.java
+++ b/src/main/java/com/conveyal/gtfs/loader/Table.java
@@ -129,6 +129,7 @@ public class Table {
         new ColorField("route_text_color",  OPTIONAL),
         // Editor fields below.
         new ShortField("publicly_visible", EDITOR, 1),
+        new ShortField("wheelchair_accessible", EDITOR, 2).permitEmptyValue(),
         // Status values are In progress (0), Pending approval (1), and Approved (2).
         new ShortField("status", EDITOR,  2)
     ).addPrimaryKey();
@@ -550,7 +551,7 @@ public class Table {
     }
 
     /**
-     * Gets the key field for the table.
+     * Gets the key field for the table. Calling this on a table that has no key field is meaningless.
      *
      * FIXME: Should this return null if hasUniqueKeyField is false? Not sure what might break if we change this...
      */

--- a/src/main/java/com/conveyal/gtfs/loader/Table.java
+++ b/src/main/java/com/conveyal/gtfs/loader/Table.java
@@ -8,6 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -642,6 +643,7 @@ public class Table {
      * table structure, but also the data from the original table. Creating table indexes is not handled by this method.
      */
     public boolean createSqlTableFrom(Connection connection, String tableToClone) {
+        long startTime = System.currentTimeMillis();
         String dropSql = String.format("drop table if exists %s", name);
         // Adding the unlogged keyword gives about 12 percent speedup on loading, but is non-standard.
         // FIXME: Which create table operation is more efficient?
@@ -654,11 +656,6 @@ public class Table {
             statement.execute(dropSql);
             LOG.info(createTableAsSql);
             statement.execute(createTableAsSql);
-//            LOG.info(createTableLikeSql);
-//            statement.execute(createTableLikeSql);
-//            LOG.info(insertAllSql);
-//            statement.execute(insertAllSql);
-
 
             // Make id column serial and set the next value based on the current max value. This code is derived from
             // https://stackoverflow.com/a/9490532/915811
@@ -722,6 +719,8 @@ public class Table {
                 e.printStackTrace();
                 return false;
             }
+        } finally {
+            LOG.info("Cloned table {} as {} in {} ms", tableToClone, name, System.currentTimeMillis() - startTime);
         }
     }
 


### PR DESCRIPTION
## Query Support
### Bounds: `maxLat`, `maxLon`, `minLat`, `minLon`
This PR adds support for GraphQL-based bounding box queries for both GTFS stops and patterns.  It does this by simply chaining conditions onto the where clause constructed for the SQL query.

### String search: `search: "Some String"`
It also adds string search for stops (on stop_id, stop_code, and stop_name) and routes (route_id, route_short_name, and route_long_name).  A column metadata query ensures that the route or stop table has the respective search fields before issuing a query to them.

## Bug fixes
This adds missing code to reconcile stop times to any changes to pattern stops (i.e., additions, deletions, transpositions) as well as linking pattern stops fields to stop times (e.g., timepoint, pickup or drop off).  Other tables with redundant data are also "linked", including trips which inherits `wheelchair_accessible` from routes and `direction_id` from patterns.