### PR TITLE
Update use_frequency field for patterns on editor snapshot

### DIFF
--- a/src/main/java/com/conveyal/gtfs/loader/JdbcGtfsSnapshotter.java
+++ b/src/main/java/com/conveyal/gtfs/loader/JdbcGtfsSnapshotter.java
@@ -193,6 +193,22 @@ public class JdbcGtfsSnapshotter {
             int calendarsUpdated = statement.executeUpdate(updateOtherSql);
             LOG.info("Updated description for {} calendars", calendarsUpdated);
         }
+        if (Table.TRIPS.name.equals(table.name)) {
+            // Update use_frequency field for patterns. This sets all patterns that have a frequency trip to use
+            // frequencies. NOTE: This is performed after copying the TRIPS table rather than after PATTERNS because
+            // both tables (plus, frequencies) need to exist for the successful operation.
+            // TODO: How should this handle patterns that have both timetable- and frequency-based trips?
+            // NOTE: The below substitution uses relative indexing. All values "%<s" reference the same arg as the
+            // previous format specifier (i.e., tablePrefix).
+            String updatePatternsSql = String.format(
+                    "update %spatterns set use_frequency = 1 " +
+                    "from (select distinct %<strips.pattern_id from %<strips, %<sfrequencies where %<sfrequencies.trip_id = %<strips.trip_id) freq " +
+                    "where freq.pattern_id = %<spatterns.pattern_id",
+                    tablePrefix);
+            LOG.info(updatePatternsSql);
+            int patternsUpdated = statement.executeUpdate(updatePatternsSql);
+            LOG.info("Updated use_frequency for {} patterns", patternsUpdated);
+        }
         // TODO: Add simple conversion from calendar_dates to schedule_exceptions if no exceptions exist? See
         // https://github.com/catalogueglobal/datatools-server/issues/80
     }

--- a/src/main/java/com/conveyal/gtfs/loader/JdbcGtfsSnapshotter.java
+++ b/src/main/java/com/conveyal/gtfs/loader/JdbcGtfsSnapshotter.java
@@ -198,12 +198,12 @@ public class JdbcGtfsSnapshotter {
             // frequencies. NOTE: This is performed after copying the TRIPS table rather than after PATTERNS because
             // both tables (plus, frequencies) need to exist for the successful operation.
             // TODO: How should this handle patterns that have both timetable- and frequency-based trips?
-            // NOTE: The below substitution uses relative indexing. All values "%<s" reference the same arg as the
-            // previous format specifier (i.e., tablePrefix).
+            // NOTE: The below substitution uses argument indexing. All values "%1$s" reference the first argument
+            // supplied (i.e., tablePrefix).
             String updatePatternsSql = String.format(
-                    "update %spatterns set use_frequency = 1 " +
-                    "from (select distinct %<strips.pattern_id from %<strips, %<sfrequencies where %<sfrequencies.trip_id = %<strips.trip_id) freq " +
-                    "where freq.pattern_id = %<spatterns.pattern_id",
+                    "update %1$spatterns set use_frequency = 1 " +
+                    "from (select distinct %1$strips.pattern_id from %1$strips, %1$sfrequencies where %1$sfrequencies.trip_id = %1$strips.trip_id) freq " +
+                    "where freq.pattern_id = %1$spatterns.pattern_id",
                     tablePrefix);
             LOG.info(updatePatternsSql);
             int patternsUpdated = statement.executeUpdate(updatePatternsSql);


### PR DESCRIPTION
Fixes #121.

Note: this updates patterns in the editor that have at least one referencing frequency trip to be "frequency-based."  What should be done if there are both frequency- and timetable-based trips referencing a single pattern?