### PR TITLE
Graphql improvements

### DIFF
--- a/src/main/java/com/conveyal/gtfs/graphql/GraphQLGtfsSchema.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/GraphQLGtfsSchema.java
@@ -297,6 +297,9 @@ public class GraphQLGtfsSchema {
                     // (i.e., nested types that typically would only be nested under another entity and only make sense
                     // with the entire set -- fares -> fare rules, trips -> stop times, patterns -> pattern stops/shapes)
                     .argument(intArg(LIMIT_ARG))
+                    .argument(stringArg(DATE_ARG))
+                    .argument(intArg(FROM_ARG))
+                    .argument(intArg(TO_ARG))
                     .dataFetcher(new JDBCFetcher("trips", "route_id"))
                     .build()
             )

--- a/src/main/java/com/conveyal/gtfs/graphql/fetchers/JDBCFetcher.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/fetchers/JDBCFetcher.java
@@ -310,12 +310,12 @@ public class JDBCFetcher implements DataFetcher<List<Map<String, Object>>> {
         sqlBuilder.append(sortBy);
         Integer limit = (Integer) arguments.get(LIMIT_ARG);
         if (limit == null) {
-            limit = DEFAULT_ROWS_TO_FETCH;
+            limit = autoLimit ? DEFAULT_ROWS_TO_FETCH : -1;
         }
         if (limit > MAX_ROWS_TO_FETCH) {
             limit = MAX_ROWS_TO_FETCH;
         }
-        if (limit == -1 || !autoLimit) {
+        if (limit == -1) {
             // Do not append limit if explicitly set to -1 or autoLimit is disabled. NOTE: this conditional block is
             // empty simply because it is clearer to define the condition in this way (vs. if limit > 0).
             // FIXME: Skipping limit is not scalable in many cases and should possibly be removed/limited.

--- a/src/test/java/com/conveyal/gtfs/graphql/GTFSGraphQLTest.java
+++ b/src/test/java/com/conveyal/gtfs/graphql/GTFSGraphQLTest.java
@@ -156,6 +156,20 @@ public class GTFSGraphQLTest {
         assertThat(queryGraphQL("feedServices.txt"), matchesSnapshot());
     }
 
+    // tests that the stop times of a feed can be fetched
+    @Test
+    public void canFetchRoutesAndFilterTripsByDateAndTime() throws IOException {
+        Map<String, Object> variables = new HashMap<String, Object>();
+        variables.put("namespace", testNamespace);
+        variables.put("date", "20170916");
+        variables.put("from", 24000);
+        variables.put("to", 28000);
+        assertThat(
+            queryGraphQL("feedRoutesAndTripsByTime.txt", variables, testDataSource),
+            matchesSnapshot()
+        );
+    }
+
     /**
      * attempt to fetch more than one record with SQL injection as inputs
      * the graphql library should properly escape the string and return 0 results for stops

--- a/src/test/java/com/conveyal/gtfs/graphql/GTFSGraphQLTest.java
+++ b/src/test/java/com/conveyal/gtfs/graphql/GTFSGraphQLTest.java
@@ -170,6 +170,12 @@ public class GTFSGraphQLTest {
         );
     }
 
+    // tests that the limit argument applies properly to a fetcher defined with autolimit set to false
+    @Test
+    public void canFetchNestedEntityWithLimit() throws IOException {
+        assertThat(queryGraphQL("feedStopsStopTimeLimit.txt"), matchesSnapshot());
+    }
+
     /**
      * attempt to fetch more than one record with SQL injection as inputs
      * the graphql library should properly escape the string and return 0 results for stops

--- a/src/test/resources/graphql/feedRoutesAndTripsByTime.txt
+++ b/src/test/resources/graphql/feedRoutesAndTripsByTime.txt
@@ -1,0 +1,13 @@
+query ($namespace: String, $date: String, $from: Int, $to: Int) {
+  feed(namespace: $namespace) {
+    routes {
+      route_id
+      route_short_name
+      route_long_name
+      route_desc
+      trips (date: $date, from: $from, to: $to) {
+        trip_id
+      }
+    }
+  }
+}

--- a/src/test/resources/graphql/feedStopsStopTimeLimit.txt
+++ b/src/test/resources/graphql/feedStopsStopTimeLimit.txt
@@ -1,0 +1,13 @@
+query ($namespace: String) {
+  feed(namespace: $namespace) {
+    feed_version
+    stops {
+      stop_id
+      stop_times(limit: 1) {
+        stop_id
+        stop_sequence
+        trip_id
+      }
+    }
+  }
+}

--- a/src/test/resources/snapshots/com/conveyal/gtfs/graphql/GTFSGraphQLTest/canFetchNestedEntityWithLimit.json
+++ b/src/test/resources/snapshots/com/conveyal/gtfs/graphql/GTFSGraphQLTest/canFetchNestedEntityWithLimit.json
@@ -1,0 +1,22 @@
+{
+  "data" : {
+    "feed" : {
+      "feed_version" : "1.0",
+      "stops" : [ {
+        "stop_id" : "4u6g",
+        "stop_times" : [ {
+          "stop_id" : "4u6g",
+          "stop_sequence" : 1,
+          "trip_id" : "a30277f8-e50a-4a85-9141-b1e0da9d429d"
+        } ]
+      }, {
+        "stop_id" : "johv",
+        "stop_times" : [ {
+          "stop_id" : "johv",
+          "stop_sequence" : 2,
+          "trip_id" : "a30277f8-e50a-4a85-9141-b1e0da9d429d"
+        } ]
+      } ]
+    }
+  }
+}

--- a/src/test/resources/snapshots/com/conveyal/gtfs/graphql/GTFSGraphQLTest/canFetchRoutesAndFilterTripsByDateAndTime.json
+++ b/src/test/resources/snapshots/com/conveyal/gtfs/graphql/GTFSGraphQLTest/canFetchRoutesAndFilterTripsByDateAndTime.json
@@ -1,0 +1,15 @@
+{
+  "data" : {
+    "feed" : {
+      "routes" : [ {
+        "route_desc" : null,
+        "route_id" : "1",
+        "route_long_name" : "Route 1",
+        "route_short_name" : "1",
+        "trips" : [ {
+          "trip_id" : "a30277f8-e50a-4a85-9141-b1e0da9d429d"
+        } ]
+      } ]
+    }
+  }
+}


### PR DESCRIPTION
- Allow filtering by date and time on the trips of a route in graphql.
- Fix a bug where the limit argument was not being properly applied in fetchers with autolimit set to false

Built off of the branch of PR #126