### PR TITLE
Fix row count fetcher sql injection and NestedJdbcFetcher empty results

### DIFF
--- a/src/main/java/com/conveyal/gtfs/graphql/fetchers/JDBCFetcher.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/fetchers/JDBCFetcher.java
@@ -435,20 +435,26 @@ public class JDBCFetcher implements DataFetcher<List<Map<String, Object>>> {
     }
 
     /**
+     * Construct filter clause with '=' (single string) and add values to list of parameters.
+     * */
+    static String makeInClause(String filterField, String string, List<String> parameters) {
+        // Add string to list of parameters (to be later used to set parameters for prepared statement).
+        parameters.add(string);
+        return String.format("%s = ?", filterField);
+    }
+
+    /**
      * Construct filter clause with '=' (single string) or 'in' (multiple strings) and add values to list of parameters.
      * */
-    private String makeInClause(String key, List<String> strings, List<String> parameters) {
-        StringBuilder sb = new StringBuilder();
-        sb.append(key);
+    static String makeInClause(String filterField, List<String> strings, List<String> parameters) {
         if (strings.size() == 1) {
-            sb.append(" = ?");
+            return makeInClause(filterField, strings.get(0), parameters);
         } else {
+            // Add strings to list of parameters (to be later used to set parameters for prepared statement).
+            parameters.addAll(strings);
             String questionMarks = String.join(", ", Collections.nCopies(strings.size(), "?"));
-            sb.append(String.format(" in (%s)", questionMarks));
+            return String.format("%s in (%s)", filterField, questionMarks);
         }
-        // Add strings to list of parameters (to be later used to set parameters for prepared statement).
-        parameters.addAll(strings);
-        return sb.toString();
     }
 
 }

--- a/src/main/java/com/conveyal/gtfs/graphql/fetchers/NestedJDBCFetcher.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/fetchers/NestedJDBCFetcher.java
@@ -106,14 +106,19 @@ public class NestedJDBCFetcher implements DataFetcher<List<Map<String, Object>>>
             }
             LOG.info("Join values: {}", joinValues.toString());
             fetchResults = fetcher.getResults(namespace, joinValues, arguments);
-            if (i < jdbcFetchers.length - 1) {
-                // Iterate over results from current fetcher to store for next iteration for all but the last iteration
-                // (last iteration will contain the final results).
+            if (fetchResults.size() == 0) {
+                // If there are no results, the following queries will have no results to join to, so we can simply
+                // return the empty list.
+                return fetchResults;
+            } else if (i < jdbcFetchers.length - 1) {
+                // Otherwise, iterate over results from current fetcher to store for next iteration for all but the last
+                // iteration (the last iteration's fetchResults will contain the final results).
                 JDBCFetcher nextFetcher = jdbcFetchers[i + 1];
                 for (Map<String, Object> entity : fetchResults) {
                     Object joinValue = entity.get(nextFetcher.parentJoinField);
                     // Store join values in multimap for
-                    if (joinValue != null) joinValuesForJoinField.put(nextFetcher.parentJoinField, joinValue.toString());
+                    if (joinValue != null)
+                        joinValuesForJoinField.put(nextFetcher.parentJoinField, joinValue.toString());
                 }
             }
         }

--- a/src/main/java/com/conveyal/gtfs/graphql/fetchers/RowCountFetcher.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/fetchers/RowCountFetcher.java
@@ -71,7 +71,8 @@ public class RowCountFetcher implements DataFetcher {
                 // FIXME Does this handle null cases?
                 // Add where clause to filter out non-matching results.
                 String filterValue = (String) parentFeedMap.get(filterField);
-                clauses.add(makeInClause(filterField, filterValue, parameters));
+                String inClause = makeInClause(filterField, filterValue, parameters);
+                clauses.add(String.join(" ", "where", inClause));
             } else if (groupByField != null) {
                 // Handle group by field and optionally handle any filter arguments passed in.
                 if (!argKeys.isEmpty()) {
@@ -85,7 +86,8 @@ public class RowCountFetcher implements DataFetcher {
                     }
                     String filterValue = (String) arguments.get(groupedFilterField);
                     if (filterValue != null) {
-                        clauses.add(makeInClause(groupedFilterField, filterValue, parameters));
+                        String inClause = makeInClause(groupedFilterField, filterValue, parameters);
+                        clauses.add(String.join(" ", "where", inClause));
                     }
                 }
                 // Finally, add group by clause.


### PR DESCRIPTION
This PR patches what appears to be the last SQL injection vulnerability and addresses #128, where the NestedJdbcFetcher incorrectly joins to an entire related table if results are missing on the "parent" entity.