### PR TITLE
v4.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>com.conveyal</groupId>
   <artifactId>gtfs-lib</artifactId>
-  <version>3.4.0-SNAPSHOT</version>
+  <version>3.3.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>


### PR DESCRIPTION
Release v4.0.0

Failed release PRs can be found here:

- #137 failed because the POM snapshot version was more than one patch version from the latest tagged release
- #136 failed because the `.travis.yml` config was bad