### PR TITLE
Graphql update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -353,7 +353,7 @@
     <dependency>
       <groupId>com.graphql-java</groupId>
       <artifactId>graphql-java</artifactId>
-      <version>4.2</version>
+      <version>10.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/src/main/java/com/conveyal/gtfs/graphql/GTFSGraphQL.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/GTFSGraphQL.java
@@ -14,12 +14,17 @@ import java.util.Map;
 
 import static com.conveyal.gtfs.graphql.fetchers.JDBCFetcher.newJdbcDataLoader;
 
-/**
- * This provides a GraphQL API around the gtfs-lib JDBC storage.
- * This just makes a Java API with the right schema available, which uses String requests and responses.
- * To make this into a web API you need to wrap it in an HTTP framework / server.
- */
 public class GTFSGraphQL {
+
+    /**
+     * Execute a graphQL request.  This method creates a new graphQL runner that is able to cache and batch sql queries
+     * during the course of obtaining the data according to the graphQL query.
+     *
+     * @param dataSource The dataSource to use in connecting to a database to make sql queries.
+     * @param query The graphQL query
+     * @param variables The variables to apply to the graphQL query
+     * @return
+     */
     public static Map<String, Object> run (DataSource dataSource, String query, Map<String,Object> variables) {
         // the registry and dataLoaders must be created upon each request to avoid caching loaded data after each request
         DataLoaderRegistry registry = new DataLoaderRegistry();
@@ -27,13 +32,16 @@ public class GTFSGraphQL {
         registry.register("jdbcfetcher", jdbcQueryDataLoader);
 
         return GraphQL.newGraphQL(GraphQLGtfsSchema.feedBasedSchema)
-            // this instrumentation implementation will dispatch all the dataloaders
-            // as each level fo the graphql query is executed and hence make batched objects
-            // available to the query and the associated DataFetchers
+            // this instrumentation implementation will dispatch all the dataloaders as each level fo the graphql query
+            // is executed and hence make batched objects available to the query and the associated DataFetchers.  This
+            // must be created new each time to avoid caching load results in future requests.
             .instrumentation(new DataLoaderDispatcherInstrumentation(registry))
             .build()
             // we now have a graphQL schema with dataloaders instrumented.  Time to make a query
             .execute(
+                // Build the execution input giving an environment context, query and variables.  The environment
+                // context is used primarily in the JDBCFetcher to get the current loader and dataSource from which
+                // the sql queries can be executed.
                 ExecutionInput.newExecutionInput()
                     .context(new GraphQLExecutionContext(jdbcQueryDataLoader, dataSource))
                     .query(query)
@@ -43,12 +51,19 @@ public class GTFSGraphQL {
             .toSpecification();
     }
 
+    /**
+     * Helper to obtain the jdbcQueryLoader.  It is critical that the same dataloader in the DataloaderRegistry /
+     * DataLoaderDispatcherInstrumentation be used otherwise the queries will never be able to be dispatched.
+     */
     public static DataLoader<JDBCFetcher.JdbcQuery, List<Map<String, Object>>> getJdbcQueryDataLoaderFromContext (
         DataFetchingEnvironment environment
     ) {
         return ((GraphQLExecutionContext)environment.getContext()).jdbcQueryDataLoader;
     }
 
+    /**
+     * Helper method to return the DataSource from the DataFetchingEnvironment
+     */
     public static DataSource getDataSourceFromContext (DataFetchingEnvironment environment) {
         DataSource dataSource = ((GraphQLExecutionContext)environment.getContext()).dataSource;
         if (dataSource == null) {
@@ -57,6 +72,9 @@ public class GTFSGraphQL {
         return dataSource;
     }
 
+    /**
+     * The object used as the DataFetchingEnvironment context in graphQL queries.
+     */
     private static class GraphQLExecutionContext {
         private final DataLoader<JDBCFetcher.JdbcQuery, List<Map<String, Object>>> jdbcQueryDataLoader;
         private final DataSource dataSource;

--- a/src/main/java/com/conveyal/gtfs/graphql/GTFSGraphQL.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/GTFSGraphQL.java
@@ -4,6 +4,7 @@ import com.conveyal.gtfs.graphql.fetchers.JDBCFetcher;
 import graphql.ExecutionInput;
 import graphql.GraphQL;
 import graphql.execution.instrumentation.dataloader.DataLoaderDispatcherInstrumentation;
+import graphql.introspection.IntrospectionQuery;
 import graphql.schema.DataFetchingEnvironment;
 import org.dataloader.DataLoader;
 import org.dataloader.DataLoaderRegistry;
@@ -50,6 +51,11 @@ public class GTFSGraphQL {
             )
             .toSpecification();
     }
+
+    public static final Map<String, Object> introspectedSchema = GraphQL.newGraphQL(GraphQLGtfsSchema.feedBasedSchema)
+        .build()
+        .execute(IntrospectionQuery.INTROSPECTION_QUERY)
+        .toSpecification();
 
     /**
      * Helper to obtain the jdbcQueryLoader.  It is critical that the same dataloader in the DataloaderRegistry /

--- a/src/main/java/com/conveyal/gtfs/graphql/GTFSGraphQL.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/GTFSGraphQL.java
@@ -1,13 +1,18 @@
 package com.conveyal.gtfs.graphql;
 
+import com.conveyal.gtfs.graphql.fetchers.JDBCFetcher;
+import graphql.ExecutionInput;
 import graphql.GraphQL;
 import graphql.execution.instrumentation.dataloader.DataLoaderDispatcherInstrumentation;
+import graphql.schema.DataFetchingEnvironment;
+import org.dataloader.DataLoader;
+import org.dataloader.DataLoaderRegistry;
 
 import javax.sql.DataSource;
-import java.sql.Connection;
-import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
 
-import static com.conveyal.gtfs.graphql.GraphQLGtfsSchema.makeRegistry;
+import static com.conveyal.gtfs.graphql.fetchers.JDBCFetcher.newJdbcDataLoader;
 
 /**
  * This provides a GraphQL API around the gtfs-lib JDBC storage.
@@ -15,33 +20,50 @@ import static com.conveyal.gtfs.graphql.GraphQLGtfsSchema.makeRegistry;
  * To make this into a web API you need to wrap it in an HTTP framework / server.
  */
 public class GTFSGraphQL {
+    public static Map<String, Object> run (DataSource dataSource, String query, Map<String,Object> variables) {
+        // the registry and dataLoaders must be created upon each request to avoid caching loaded data after each request
+        DataLoaderRegistry registry = new DataLoaderRegistry();
+        DataLoader<JDBCFetcher.JdbcQuery, List<Map<String, Object>>> jdbcQueryDataLoader = newJdbcDataLoader();
+        registry.register("jdbcfetcher", jdbcQueryDataLoader);
 
-    private static DataSource dataSource;
-
-    // TODO Is it correct to share one of these objects between many instances? Is it supposed to be long-lived or threadsafe?
-    // Analysis-backend creates a new GraphQL object on every request.
-    private static GraphQL GRAPHQL;
-
-    /** Username and password can be null if connecting to a local instance with host-based authentication. */
-    public static void initialize (DataSource dataSource) {
-        GTFSGraphQL.dataSource = dataSource;
-        GRAPHQL = GraphQL.newGraphQL(GraphQLGtfsSchema.feedBasedSchema)
+        return GraphQL.newGraphQL(GraphQLGtfsSchema.feedBasedSchema)
             // this instrumentation implementation will dispatch all the dataloaders
             // as each level fo the graphql query is executed and hence make batched objects
             // available to the query and the associated DataFetchers
-            .instrumentation(new DataLoaderDispatcherInstrumentation(makeRegistry()))
-            .build();
+            .instrumentation(new DataLoaderDispatcherInstrumentation(registry))
+            .build()
+            // we now have a graphQL schema with dataloaders instrumented.  Time to make a query
+            .execute(
+                ExecutionInput.newExecutionInput()
+                    .context(new GraphQLExecutionContext(jdbcQueryDataLoader, dataSource))
+                    .query(query)
+                    .variables(variables)
+                    .build()
+            )
+            .toSpecification();
     }
 
-    public static Connection getConnection() {
-        try {
-            return dataSource.getConnection();
-        } catch (SQLException ex) {
-            throw new RuntimeException(ex);
+    public static DataLoader<JDBCFetcher.JdbcQuery, List<Map<String, Object>>> getJdbcQueryDataLoaderFromContext (
+        DataFetchingEnvironment environment
+    ) {
+        return ((GraphQLExecutionContext)environment.getContext()).jdbcQueryDataLoader;
+    }
+
+    public static DataSource getDataSourceFromContext (DataFetchingEnvironment environment) {
+        DataSource dataSource = ((GraphQLExecutionContext)environment.getContext()).dataSource;
+        if (dataSource == null) {
+            throw new RuntimeException("DataSource is not defined, unable to make sql query!");
         }
+        return dataSource;
     }
 
-    public static GraphQL getGraphQl () {
-        return GRAPHQL;
+    private static class GraphQLExecutionContext {
+        private final DataLoader<JDBCFetcher.JdbcQuery, List<Map<String, Object>>> jdbcQueryDataLoader;
+        private final DataSource dataSource;
+
+        private GraphQLExecutionContext(DataLoader<JDBCFetcher.JdbcQuery, List<Map<String, Object>>> jdbcQueryDataLoader, DataSource dataSource) {
+            this.jdbcQueryDataLoader = jdbcQueryDataLoader;
+            this.dataSource = dataSource;
+        }
     }
 }

--- a/src/main/java/com/conveyal/gtfs/graphql/GraphQLGtfsSchema.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/GraphQLGtfsSchema.java
@@ -14,6 +14,7 @@ import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLScalarType;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLTypeReference;
+import org.dataloader.DataLoaderRegistry;
 
 import java.sql.Array;
 import java.sql.SQLException;
@@ -24,7 +25,18 @@ import static com.conveyal.gtfs.graphql.GraphQLUtil.intt;
 import static com.conveyal.gtfs.graphql.GraphQLUtil.multiStringArg;
 import static com.conveyal.gtfs.graphql.GraphQLUtil.string;
 import static com.conveyal.gtfs.graphql.GraphQLUtil.stringArg;
-import static com.conveyal.gtfs.graphql.fetchers.JDBCFetcher.*;
+import static com.conveyal.gtfs.graphql.fetchers.JDBCFetcher.DATE_ARG;
+import static com.conveyal.gtfs.graphql.fetchers.JDBCFetcher.FROM_ARG;
+import static com.conveyal.gtfs.graphql.fetchers.JDBCFetcher.ID_ARG;
+import static com.conveyal.gtfs.graphql.fetchers.JDBCFetcher.LIMIT_ARG;
+import static com.conveyal.gtfs.graphql.fetchers.JDBCFetcher.MAX_LAT;
+import static com.conveyal.gtfs.graphql.fetchers.JDBCFetcher.MAX_LON;
+import static com.conveyal.gtfs.graphql.fetchers.JDBCFetcher.MIN_LAT;
+import static com.conveyal.gtfs.graphql.fetchers.JDBCFetcher.MIN_LON;
+import static com.conveyal.gtfs.graphql.fetchers.JDBCFetcher.OFFSET_ARG;
+import static com.conveyal.gtfs.graphql.fetchers.JDBCFetcher.SEARCH_ARG;
+import static com.conveyal.gtfs.graphql.fetchers.JDBCFetcher.TO_ARG;
+import static com.conveyal.gtfs.graphql.fetchers.JDBCFetcher.jdbcDataLoader;
 import static graphql.Scalars.GraphQLFloat;
 import static graphql.Scalars.GraphQLInt;
 import static graphql.Scalars.GraphQLString;
@@ -783,6 +795,12 @@ public class GraphQLGtfsSchema {
             // .mutation(someMutation)
             .build();
 
+    public static DataLoaderRegistry makeRegistry() {
+        // DataLoaderRegistry is a place to register all data loaders in that needs to be dispatched together
+        DataLoaderRegistry registry = new DataLoaderRegistry();
+        registry.register("jdbcfetcher", jdbcDataLoader);
+        return registry;
+    }
 
     private static class StringCoercing implements Coercing {
         @Override

--- a/src/main/java/com/conveyal/gtfs/graphql/GraphQLGtfsSchema.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/GraphQLGtfsSchema.java
@@ -14,7 +14,6 @@ import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLScalarType;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLTypeReference;
-import org.dataloader.DataLoaderRegistry;
 
 import java.sql.Array;
 import java.sql.SQLException;
@@ -36,7 +35,6 @@ import static com.conveyal.gtfs.graphql.fetchers.JDBCFetcher.MIN_LON;
 import static com.conveyal.gtfs.graphql.fetchers.JDBCFetcher.OFFSET_ARG;
 import static com.conveyal.gtfs.graphql.fetchers.JDBCFetcher.SEARCH_ARG;
 import static com.conveyal.gtfs.graphql.fetchers.JDBCFetcher.TO_ARG;
-import static com.conveyal.gtfs.graphql.fetchers.JDBCFetcher.jdbcDataLoader;
 import static graphql.Scalars.GraphQLFloat;
 import static graphql.Scalars.GraphQLInt;
 import static graphql.Scalars.GraphQLString;
@@ -794,13 +792,6 @@ public class GraphQLGtfsSchema {
             // TODO: Add mutations.
             // .mutation(someMutation)
             .build();
-
-    public static DataLoaderRegistry makeRegistry() {
-        // DataLoaderRegistry is a place to register all data loaders in that needs to be dispatched together
-        DataLoaderRegistry registry = new DataLoaderRegistry();
-        registry.register("jdbcfetcher", jdbcDataLoader);
-        return registry;
-    }
 
     private static class StringCoercing implements Coercing {
         @Override

--- a/src/main/java/com/conveyal/gtfs/graphql/GraphQLGtfsSchema.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/GraphQLGtfsSchema.java
@@ -357,6 +357,7 @@ public class GraphQLGtfsSchema {
                     .type(new GraphQLList(routeType))
                     .argument(stringArg("namespace"))
                     .argument(stringArg(SEARCH_ARG))
+                    .argument(intArg(LIMIT_ARG))
                     .dataFetcher(new NestedJDBCFetcher(
                             new JDBCFetcher("pattern_stops", "stop_id", null, false),
                             new JDBCFetcher("patterns", "pattern_id", null, false),

--- a/src/main/java/com/conveyal/gtfs/graphql/GraphQLUtil.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/GraphQLUtil.java
@@ -57,4 +57,11 @@ public class GraphQLUtil {
                 .build();
     }
 
+    public static String namespacedTableName(String namespace, String tableName) {
+        return String.format("%s.%s", namespace, tableName);
+    }
+
+    public static String namespacedTableFieldName(String namespace, String tableName, String tableField) {
+        return String.format("%s.%s.%s", namespace, tableName, tableField);
+    }
 }

--- a/src/main/java/com/conveyal/gtfs/graphql/GraphQLUtil.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/GraphQLUtil.java
@@ -57,10 +57,16 @@ public class GraphQLUtil {
                 .build();
     }
 
+    /**
+     * Helper method to get the namespaced table name
+     */
     public static String namespacedTableName(String namespace, String tableName) {
         return String.format("%s.%s", namespace, tableName);
     }
 
+    /**
+     * Helper method to get the string of the column name with the namespace and table name
+     */
     public static String namespacedTableFieldName(String namespace, String tableName, String tableField) {
         return String.format("%s.%s.%s", namespace, tableName, tableField);
     }

--- a/src/main/java/com/conveyal/gtfs/graphql/GraphQLUtil.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/GraphQLUtil.java
@@ -1,9 +1,9 @@
 package com.conveyal.gtfs.graphql;
 
-import graphql.schema.FieldDataFetcher;
 import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLList;
+import graphql.schema.PropertyDataFetcher;
 
 import static graphql.Scalars.GraphQLFloat;
 import static graphql.Scalars.GraphQLInt;
@@ -17,7 +17,7 @@ public class GraphQLUtil {
         return newFieldDefinition()
                 .name(name)
                 .type(GraphQLString)
-                .dataFetcher(new FieldDataFetcher(name))
+                .dataFetcher(new PropertyDataFetcher(name))
                 .build();
     }
 
@@ -25,7 +25,7 @@ public class GraphQLUtil {
         return newFieldDefinition()
                 .name(name)
                 .type(GraphQLInt)
-                .dataFetcher(new FieldDataFetcher(name))
+                .dataFetcher(new PropertyDataFetcher(name))
                 .build();
     }
 

--- a/src/main/java/com/conveyal/gtfs/graphql/fetchers/ErrorCountFetcher.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/fetchers/ErrorCountFetcher.java
@@ -8,6 +8,7 @@ import org.apache.commons.dbutils.DbUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -37,9 +38,10 @@ public class ErrorCountFetcher implements DataFetcher {
         List<ErrorCount> errorCounts = new ArrayList();
         Map<String, Object> parentFeedMap = environment.getSource();
         String namespace = (String) parentFeedMap.get("namespace");
+        DataSource dataSource = GTFSGraphQL.getDataSourceFromContext(environment);
         Connection connection = null;
         try {
-            connection = GTFSGraphQL.getConnection();
+            connection = dataSource.getConnection();
             Statement statement = connection.createStatement();
             String sql = String.format("select error_type, count(*) from %s.errors group by error_type", namespace);
             LOG.info("SQL: {}", sql);

--- a/src/main/java/com/conveyal/gtfs/graphql/fetchers/FeedFetcher.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/fetchers/FeedFetcher.java
@@ -6,6 +6,7 @@ import graphql.schema.DataFetchingEnvironment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
@@ -27,12 +28,13 @@ public class FeedFetcher implements DataFetcher {
     @Override
     public Map<String, Object> get (DataFetchingEnvironment environment) {
         String namespace = environment.getArgument("namespace"); // This is the unique table prefix (the "schema").
+        DataSource dataSource = GTFSGraphQL.getDataSourceFromContext(environment);
         validateNamespace(namespace);
         StringBuilder sqlBuilder = new StringBuilder();
         sqlBuilder.append(String.format("select * from feeds where namespace = '%s'", namespace));
         Connection connection = null;
         try {
-            connection = GTFSGraphQL.getConnection();
+            connection = dataSource.getConnection();
             Statement statement = connection.createStatement();
             LOG.info("SQL: {}", sqlBuilder.toString());
             if (statement.execute(sqlBuilder.toString())) {

--- a/src/main/java/com/conveyal/gtfs/graphql/fetchers/FeedFetcher.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/fetchers/FeedFetcher.java
@@ -14,6 +14,8 @@ import java.sql.Statement;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.conveyal.gtfs.graphql.fetchers.JDBCFetcher.validateNamespace;
+
 /**
  * Fetch the summary row for a particular loaded feed, based on its namespace.
  * This essentially gets the row from the top-level summary table of all feeds that have been loaded into the database.
@@ -25,6 +27,7 @@ public class FeedFetcher implements DataFetcher {
     @Override
     public Map<String, Object> get (DataFetchingEnvironment environment) {
         String namespace = environment.getArgument("namespace"); // This is the unique table prefix (the "schema").
+        validateNamespace(namespace);
         StringBuilder sqlBuilder = new StringBuilder();
         sqlBuilder.append(String.format("select * from feeds where namespace = '%s'", namespace));
         Connection connection = null;

--- a/src/main/java/com/conveyal/gtfs/graphql/fetchers/JDBCFetcher.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/fetchers/JDBCFetcher.java
@@ -40,7 +40,7 @@ import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
 /**
  * A generic fetcher to get fields out of an SQL database table.
  */
-public class JDBCFetcher implements DataFetcher<Object> {
+public class JDBCFetcher implements DataFetcher<CompletableFuture<List<Map<String, Object>>>> {
 
     public static final Logger LOG = LoggerFactory.getLogger(JDBCFetcher.class);
 
@@ -529,7 +529,7 @@ public class JDBCFetcher implements DataFetcher<Object> {
      * Helper class for batching sql queries to the dataloader.  The dataloader is sent instances of this class which it
      * will use to create queries.  We need to override the equals and hashcode methods to ensure proper equality checks
      * when the dataloader is matching the results of the query to the place where it should return the result as part
-     * of the graphql response.
+     * of the graphql response.  This class also serves as a lookup key for the dataloader cache.
      */
     public static class JdbcQuery {
         public String namespace;

--- a/src/main/java/com/conveyal/gtfs/graphql/fetchers/JDBCFetcher.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/fetchers/JDBCFetcher.java
@@ -206,7 +206,7 @@ public class JDBCFetcher implements DataFetcher<Object> {
      * get some data by fetching data from the database.
      */
     @Override
-    public Object get (DataFetchingEnvironment environment) {
+    public CompletableFuture<List<Map<String, Object>>> get (DataFetchingEnvironment environment) {
         // GetSource is the context in which this this DataFetcher has been created, in this case a map representing
         // the parent feed (FeedFetcher).
         Map<String, Object> parentEntityMap = environment.getSource();
@@ -231,7 +231,7 @@ public class JDBCFetcher implements DataFetcher<Object> {
             String inClauseString = inClauseValue == null ? null : inClauseValue.toString();
             inClauseValues.add(inClauseString);
             if (inClauseValue == null) {
-                return new ArrayList<>();
+                return new CompletableFuture<>();
             }
         }
         Map<String, Object> arguments = environment.getArguments();
@@ -265,7 +265,7 @@ public class JDBCFetcher implements DataFetcher<Object> {
      * by DataFetchers that get their data by making a sql query and get their results in the format of
      * List<Map<String, Object>>.
      */
-    Object getResults (
+    CompletableFuture<List<Map<String, Object>>> getResults (
         DataLoader<JdbcQuery, List<Map<String, Object>>> jdbcDataLoader,
         DataSource dataSource,
         String namespace,

--- a/src/main/java/com/conveyal/gtfs/graphql/fetchers/JDBCFetcher.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/fetchers/JDBCFetcher.java
@@ -146,73 +146,94 @@ public class JDBCFetcher implements DataFetcher<List<Map<String, Object>>> {
 
         // If we are fetching an item nested within a GTFS entity in the GraphQL query, we want to add an SQL "where"
         // clause using the values found here. Note, these are used in the below getResults call.
-        List<String> parentJoinValues = new ArrayList<>();
+        List<String> inClauseValues = new ArrayList<>();
         if (parentJoinField != null) {
             Map<String, Object> enclosingEntity = environment.getSource();
             // FIXME: THIS IS BROKEN if parentJoinValue is null!!!!
-            Object parentJoinValue = enclosingEntity.get(parentJoinField);
+            Object inClauseValue = enclosingEntity.get(parentJoinField);
             // Check for null parentJoinValue to protect against NPE.
-            String parentJoinString = parentJoinValue == null ? null : parentJoinValue.toString();
-            parentJoinValues.add(parentJoinString);
-            if (parentJoinValue == null) {
+            String inClauseString = inClauseValue == null ? null : inClauseValue.toString();
+            inClauseValues.add(inClauseString);
+            if (inClauseValue == null) {
                 return new ArrayList<>();
             }
         }
         Map<String, Object> arguments = environment.getArguments();
 
-        return getResults(namespace, parentJoinValues, arguments);
+        return getResults(namespace, inClauseValues, arguments);
+    }
+
+    List<Map<String, Object>> getResults (
+        String namespace,
+        List<String> inClauseValues,
+        Map<String, Object> arguments
+    ) {
+        // We could select only the requested fields by examining environment.getFields(), but we just get them all.
+        // The advantage of selecting * is that we don't need to validate the field names.
+        // All the columns will be loaded into the Map<String, Object>,
+        // but only the requested fields will be fetched from that Map using a MapFetcher.
+        StringBuilder sqlBuilder = new StringBuilder();
+        sqlBuilder.append("select *");
+        return getResults(
+            namespace,
+            inClauseValues,
+            arguments,
+            // No additional prepared statement parameters, where conditions or tables are needed beyond those added by
+            // default in the next method.
+            new ArrayList<>(),
+            new ArrayList<>(),
+            new HashSet<>(),
+            sqlBuilder
+        );
     }
 
     /**
      * Handle fetching functionality for a given namespace, set of join values, and arguments. This is broken out from
      * the standard get function so that it can be reused in other fetchers (i.e., NestedJdbcFetcher)
      */
-    List<Map<String, Object>> getResults (String namespace, List<String> parentJoinValues, Map<String, Object> arguments) {
-        // Track the parameters for setting prepared statement parameters
-        List<String> parameters = new ArrayList<>();
+    List<Map<String, Object>> getResults (
+        String namespace,
+        List<String> inClauseValues,
+        Map<String, Object> graphQLQueryArguments,
+        List<String> preparedStatementParameters,
+        List<String> whereConditions,
+        Set<String> fromTables,
+        StringBuilder sqlStatementStringBuilder
+    ) {
         // This will contain one Map<String, Object> for each row fetched from the database table.
         List<Map<String, Object>> results = new ArrayList<>();
-        if (arguments == null) arguments = new HashMap<>();
+        if (graphQLQueryArguments == null) graphQLQueryArguments = new HashMap<>();
         // Ensure namespace exists and is clean. Note: FeedFetcher will have executed before this and validated that an
         // entry exists in the feeds table and the schema actually exists in the database.
         validateNamespace(namespace);
-        StringBuilder sqlBuilder = new StringBuilder();
 
-        // We could select only the requested fields by examining environment.getFields(), but we just get them all.
-        // The advantage of selecting * is that we don't need to validate the field names.
-        // All the columns will be loaded into the Map<String, Object>,
-        // but only the requested fields will be fetched from that Map using a MapFetcher.
-        Set<String> fromTables = new HashSet<>();
-        // By default, select only from the primary table. Other tables may be added to this list to handle joins.
+        // The primary table being selected from is added here. Other tables may have been / will be added to this list to handle joins.
         fromTables.add(String.join(".", namespace, tableName));
-        sqlBuilder.append("select *");
 
-        // We will build up additional sql clauses in this List (note: must be a List so that the order is preserved).
-        List<String> conditions = new ArrayList<>();
         // The order by clause will go here.
         String sortBy = "";
         // If we are fetching an item nested within a GTFS entity in the GraphQL query, we want to add an SQL "where"
         // clause. This could conceivably be done automatically, but it's clearer to just express the intent.
         // Note, this is assuming the type of the field in the parent is a string.
-        if (parentJoinField != null && parentJoinValues != null && !parentJoinValues.isEmpty()) {
-            conditions.add(makeInClause(parentJoinField, parentJoinValues, parameters));
+        if (parentJoinField != null && inClauseValues != null && !inClauseValues.isEmpty()) {
+            whereConditions.add(makeInClause(parentJoinField, inClauseValues, preparedStatementParameters));
         }
         if (sortField != null) {
             // Sort field is not provided by user input, so it's ok to add here (i.e., it's not prone to SQL injection).
             sortBy = String.format(" order by %s", sortField);
         }
-        Set<String> argumentKeys = arguments.keySet();
+        Set<String> argumentKeys = graphQLQueryArguments.keySet();
         for (String key : argumentKeys) {
             // The pagination, bounding box, and date/time args should all be skipped here because they are handled
             // separately below from standard args (pagination becomes limit/offset clauses, bounding box applies to
             // stops table, and date/time args filter stop times. All other args become "where X in A, B, C" clauses.
             if (argsToSkip.contains(key)) continue;
             if (ID_ARG.equals(key)) {
-                Integer value = (Integer) arguments.get(key);
-                conditions.add(String.join(" = ", "id", value.toString()));
+                Integer value = (Integer) graphQLQueryArguments.get(key);
+                whereConditions.add(String.join(" = ", "id", value.toString()));
             } else {
-                List<String> values = (List<String>) arguments.get(key);
-                if (values != null && !values.isEmpty()) conditions.add(makeInClause(key, values, parameters));
+                List<String> values = (List<String>) graphQLQueryArguments.get(key);
+                if (values != null && !values.isEmpty()) whereConditions.add(makeInClause(key, values, preparedStatementParameters));
             }
         }
         if (argumentKeys.containsAll(boundingBoxArgs)) {
@@ -222,7 +243,7 @@ public class JDBCFetcher implements DataFetcher<List<Map<String, Object>>> {
             // operating on the patterns table, a SELECT DISTINCT patterns query will be constructed with a join to
             // stops and pattern stops.
             for (String bound : boundingBoxArgs) {
-                Double value = (Double) arguments.get(bound);
+                Double value = (Double) graphQLQueryArguments.get(bound);
                 // Determine delimiter/equality operator based on min/max
                 String delimiter = bound.startsWith("max") ? " <= " : " >= ";
                 // Determine field based on lat/lon
@@ -232,7 +253,7 @@ public class JDBCFetcher implements DataFetcher<List<Map<String, Object>>> {
                 boundsConditions.add(String.join(delimiter, fieldWithNamespace, value.toString()));
             }
             if ("stops".equals(tableName)) {
-                conditions.addAll(boundsConditions);
+                whereConditions.addAll(boundsConditions);
             } else if ("patterns".equals(tableName)) {
                 // Add from table as unique_pattern_ids_in_bounds to match patterns table -> pattern stops -> stops
                 fromTables.add(
@@ -243,7 +264,7 @@ public class JDBCFetcher implements DataFetcher<List<Map<String, Object>>> {
                                 String.join(" and ", boundsConditions),
                                 namespace
                         ));
-                conditions.add(String.format("%s.patterns.pattern_id = unique_pattern_ids_in_bounds.pattern_id", namespace));
+                whereConditions.add(String.format("%s.patterns.pattern_id = unique_pattern_ids_in_bounds.pattern_id", namespace));
             }
         }
         if (argumentKeys.contains(DATE_ARG)) {
@@ -253,7 +274,7 @@ public class JDBCFetcher implements DataFetcher<List<Map<String, Object>>> {
             // service_dates table. In other words, feeds generated by the editor cannot be queried with the date/time args.
             String tripsTable = String.format("%s.trips", namespace);
             fromTables.add(tripsTable);
-            String date = getDateArgument(arguments);
+            String date = getDateArgument(graphQLQueryArguments);
             // Gather all service IDs that run on the provided date.
             fromTables.add(String.format(
                     "(select distinct service_id from %s.service_dates where service_date = ?) as unique_service_ids_in_operation",
@@ -261,11 +282,11 @@ public class JDBCFetcher implements DataFetcher<List<Map<String, Object>>> {
             );
             // Add date to beginning of parameters list (it is used to pre-select a table in the from clause before any
             // other conditions or parameters are appended).
-            parameters.add(0, date);
+            preparedStatementParameters.add(0, date);
             if (argumentKeys.contains(FROM_ARG) && argumentKeys.contains(TO_ARG)) {
                 // Determine which trips start in the specified time window by joining to filtered stop times.
                 String timeFilteredTrips = "trips_beginning_in_time_period";
-                conditions.add(String.format("%s.trip_id = %s.trip_id", timeFilteredTrips, tripsTable));
+                whereConditions.add(String.format("%s.trip_id = %s.trip_id", timeFilteredTrips, tripsTable));
                 // Select all trip IDs that start during the specified time window. Note: the departure and arrival times
                 // are divided by 86399 to account for trips that begin after midnight. FIXME: Should this be 86400?
                 fromTables.add(String.format(
@@ -273,16 +294,16 @@ public class JDBCFetcher implements DataFetcher<List<Map<String, Object>>> {
                         "from (select distinct on (trip_id) * from %s.stop_times order by trip_id, stop_sequence) as first_stop_times " +
                         "where departure_time %% 86399 >= %d and departure_time %% 86399 <= %d) as %s",
                         namespace,
-                        (int) arguments.get(FROM_ARG),
-                        (int) arguments.get(TO_ARG),
+                        (int) graphQLQueryArguments.get(FROM_ARG),
+                        (int) graphQLQueryArguments.get(TO_ARG),
                         timeFilteredTrips));
             }
             // Join trips to service_dates (unique_service_ids_in_operation).
-            conditions.add(String.format("%s.service_id = unique_service_ids_in_operation.service_id", tripsTable));
+            whereConditions.add(String.format("%s.service_id = unique_service_ids_in_operation.service_id", tripsTable));
         }
         if (argumentKeys.contains(SEARCH_ARG)) {
             // Handle string search argument
-            String value = (String) arguments.get(SEARCH_ARG);
+            String value = (String) graphQLQueryArguments.get(SEARCH_ARG);
             if (!value.isEmpty()) {
                 // Only apply string search if string is not empty.
                 Set<String> searchFields = getSearchFields(namespace);
@@ -292,23 +313,23 @@ public class JDBCFetcher implements DataFetcher<List<Map<String, Object>>> {
                     // FIXME: is ILIKE compatible with non-Postgres? LIKE doesn't work well enough (even when setting
                     // the strings to lower case).
                     searchClauses.add(String.format("%s ILIKE ?", field));
-                    parameters.add(String.format("%%%s%%", value));
+                    preparedStatementParameters.add(String.format("%%%s%%", value));
                 }
                 if (!searchClauses.isEmpty()) {
                     // Wrap string search in parentheses to isolate from other conditions.
-                    conditions.add(String.format(("(%s)"), String.join(" OR ", searchClauses)));
+                    whereConditions.add(String.format(("(%s)"), String.join(" OR ", searchClauses)));
                 }
             }
         }
-        sqlBuilder.append(String.format(" from %s", String.join(", ", fromTables)));
-        if (!conditions.isEmpty()) {
-            sqlBuilder.append(" where ");
-            sqlBuilder.append(String.join(" and ", conditions));
+        sqlStatementStringBuilder.append(String.format(" from %s", String.join(", ", fromTables)));
+        if (!whereConditions.isEmpty()) {
+            sqlStatementStringBuilder.append(" where ");
+            sqlStatementStringBuilder.append(String.join(" and ", whereConditions));
         }
         // The default value for sortBy is an empty string, so it's safe to always append it here. Also, there is no
         // threat of SQL injection because the sort field value is not user input.
-        sqlBuilder.append(sortBy);
-        Integer limit = (Integer) arguments.get(LIMIT_ARG);
+        sqlStatementStringBuilder.append(sortBy);
+        Integer limit = (Integer) graphQLQueryArguments.get(LIMIT_ARG);
         if (limit == null) {
             limit = autoLimit ? DEFAULT_ROWS_TO_FETCH : -1;
         }
@@ -320,18 +341,18 @@ public class JDBCFetcher implements DataFetcher<List<Map<String, Object>>> {
             // empty simply because it is clearer to define the condition in this way (vs. if limit > 0).
             // FIXME: Skipping limit is not scalable in many cases and should possibly be removed/limited.
         } else {
-            sqlBuilder.append(" limit ").append(limit);
+            sqlStatementStringBuilder.append(" limit ").append(limit);
         }
-        Integer offset = (Integer) arguments.get(OFFSET_ARG);
+        Integer offset = (Integer) graphQLQueryArguments.get(OFFSET_ARG);
         if (offset != null && offset >= 0) {
-            sqlBuilder.append(" offset ").append(offset);
+            sqlStatementStringBuilder.append(" offset ").append(offset);
         }
         Connection connection = null;
         try {
             connection = GTFSGraphQL.getConnection();
-            PreparedStatement preparedStatement = connection.prepareStatement(sqlBuilder.toString());
+            PreparedStatement preparedStatement = connection.prepareStatement(sqlStatementStringBuilder.toString());
             int oneBasedIndex = 1;
-            for (String parameter : parameters) {
+            for (String parameter : preparedStatementParameters) {
                 preparedStatement.setString(oneBasedIndex++, parameter);
             }
             // This logging produces a lot of noise during testing due to large numbers of joined sub-queries
@@ -437,7 +458,7 @@ public class JDBCFetcher implements DataFetcher<List<Map<String, Object>>> {
     /**
      * Construct filter clause with '=' (single string) and add values to list of parameters.
      * */
-    static String makeInClause(String filterField, String string, List<String> parameters) {
+    static String filterEquals(String filterField, String string, List<String> parameters) {
         // Add string to list of parameters (to be later used to set parameters for prepared statement).
         parameters.add(string);
         return String.format("%s = ?", filterField);
@@ -448,7 +469,7 @@ public class JDBCFetcher implements DataFetcher<List<Map<String, Object>>> {
      * */
     static String makeInClause(String filterField, List<String> strings, List<String> parameters) {
         if (strings.size() == 1) {
-            return makeInClause(filterField, strings.get(0), parameters);
+            return filterEquals(filterField, strings.get(0), parameters);
         } else {
             // Add strings to list of parameters (to be later used to set parameters for prepared statement).
             parameters.addAll(strings);

--- a/src/main/java/com/conveyal/gtfs/graphql/fetchers/NestedJDBCFetcher.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/fetchers/NestedJDBCFetcher.java
@@ -14,6 +14,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static com.conveyal.gtfs.graphql.GTFSGraphQL.getDataSourceFromContext;
+import static com.conveyal.gtfs.graphql.GTFSGraphQL.getJdbcQueryDataLoaderFromContext;
 import static com.conveyal.gtfs.graphql.GraphQLUtil.multiStringArg;
 import static com.conveyal.gtfs.graphql.GraphQLUtil.namespacedTableFieldName;
 import static com.conveyal.gtfs.graphql.GraphQLUtil.namespacedTableName;
@@ -124,6 +126,8 @@ public class NestedJDBCFetcher implements DataFetcher<Object> {
                     );
                     // Make the query and return the results!
                     return fetcher.getResults(
+                        getJdbcQueryDataLoaderFromContext(environment),
+                        getDataSourceFromContext(environment),
                         namespace,
                         new ArrayList<>(),
                         graphQLQueryArguemnts,

--- a/src/main/java/com/conveyal/gtfs/graphql/fetchers/NestedJDBCFetcher.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/fetchers/NestedJDBCFetcher.java
@@ -13,6 +13,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
 import static com.conveyal.gtfs.graphql.GTFSGraphQL.getDataSourceFromContext;
 import static com.conveyal.gtfs.graphql.GTFSGraphQL.getJdbcQueryDataLoaderFromContext;
@@ -69,7 +70,7 @@ public class NestedJDBCFetcher implements DataFetcher<Object> {
      * executed by graphQL at some strategic point in time.
      */
     @Override
-    public Object get (DataFetchingEnvironment environment) {
+    public CompletableFuture<List<Map<String, Object>>> get (DataFetchingEnvironment environment) {
         // GetSource is the context in which this this DataFetcher has been created, in this case a map representing
         // the parent feed (FeedFetcher).
         Map<String, Object> parentEntityMap = environment.getSource();
@@ -100,7 +101,7 @@ public class NestedJDBCFetcher implements DataFetcher<Object> {
                 String inClauseValue = (String) enclosingEntity.get(fetcher.parentJoinField);
                 // Check for null parentJoinValue to protect against NPE.
                 if (inClauseValue == null) {
-                    return new ArrayList<>();
+                    return new CompletableFuture<>();
                 } else {
                     inClauseValues.add(inClauseValue);
                 }
@@ -147,6 +148,6 @@ public class NestedJDBCFetcher implements DataFetcher<Object> {
         }
         // This piece of code will never be reached because of how things get returned above.
         // But it's here to make java happy.
-        return new ArrayList<>();
+        return new CompletableFuture<>();
     }
 }

--- a/src/main/java/com/conveyal/gtfs/graphql/fetchers/NestedJDBCFetcher.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/fetchers/NestedJDBCFetcher.java
@@ -135,7 +135,7 @@ public class NestedJDBCFetcher implements DataFetcher<CompletableFuture<List<Map
         // Make the query and return the results!
         return previousFetcher.getResults(
             environment,
-            sqlStatementStringBuilder,
+            sqlStatementStringBuilder.toString(),
             fromTables,
             whereConditions,
             preparedStatementParameters

--- a/src/main/java/com/conveyal/gtfs/graphql/fetchers/NestedJDBCFetcher.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/fetchers/NestedJDBCFetcher.java
@@ -1,8 +1,6 @@
 package com.conveyal.gtfs.graphql.fetchers;
 
 import com.conveyal.gtfs.graphql.GraphQLGtfsSchema;
-import com.google.common.collect.ListMultimap;
-import com.google.common.collect.MultimapBuilder;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.GraphQLFieldDefinition;
@@ -63,9 +61,6 @@ public class NestedJDBCFetcher implements DataFetcher<List<Map<String, Object>>>
 
     @Override
     public List<Map<String, Object>> get (DataFetchingEnvironment environment) {
-        // Store the join values here.
-        ListMultimap<String, String> joinValuesForJoinField = MultimapBuilder.treeKeys().arrayListValues().build();
-
         // GetSource is the context in which this this DataFetcher has been created, in this case a map representing
         // the parent feed (FeedFetcher).
         Map<String, Object> parentEntityMap = environment.getSource();
@@ -79,54 +74,6 @@ public class NestedJDBCFetcher implements DataFetcher<List<Map<String, Object>>>
         // implied limit of 50 records). For now, the autoLimit field has been added to JDBCFetcher, so that certain
         // fetchers (like the nested ones used solely for joins here) will not apply the limit by default.
         Map<String, Object> graphQLQueryArguemnts = environment.getArguments();;
-
-//        // Store each iteration's fetch results here.
-//        List<Map<String, Object>> fetchResults = null;
-//        for (int i = 0; i < jdbcFetchers.length; i++) {
-//            JDBCFetcher fetcher = jdbcFetchers[i];
-//            List<String> joinValues;
-//            if (i == 0) {
-//                // For first iteration of fetching, use parent entity to get join values.
-//                Map<String, Object> enclosingEntity = environment.getSource();
-//                // FIXME SQL injection: enclosing entity's ID could contain malicious character sequences; quote and sanitize the string.
-//                // FIXME: THIS IS BROKEN if parentJoinValue is null!!!!
-//                Object parentJoinValue = enclosingEntity.get(fetcher.parentJoinField);
-//                // Check for null parentJoinValue to protect against NPE.
-//                joinValues = new ArrayList<>();
-//                String parentJoinString = parentJoinValue == null ? null : parentJoinValue.toString();
-//                joinValues.add(parentJoinString);
-//                if (parentJoinValue == null) {
-//                    return new ArrayList<>();
-//                }
-//            } else {
-//                // Otherwise, get join values stored by previous fetcher.
-//                joinValues = joinValuesForJoinField.get(fetcher.parentJoinField);
-//                if (i == jdbcFetchers.length - 1) {
-//                    // Apply arguments only to the final fetched table
-//                    arguments = environment.getArguments();
-//                    LOG.info("{} args: {}", fetcher.tableName, arguments.keySet().toString());
-//                }
-//            }
-//            LOG.info("Join values: {}", joinValues.toString());
-//            fetchResults = fetcher.getResults(namespace, joinValues, arguments);
-//            if (fetchResults.size() == 0) {
-//                // If there are no results, the following queries will have no results to join to, so we can simply
-//                // return the empty list.
-//                return fetchResults;
-//            } else if (i < jdbcFetchers.length - 1) {
-//                // Otherwise, iterate over results from current fetcher to store for next iteration for all but the last
-//                // iteration (the last iteration's fetchResults will contain the final results).
-//                JDBCFetcher nextFetcher = jdbcFetchers[i + 1];
-//                for (Map<String, Object> entity : fetchResults) {
-//                    Object joinValue = entity.get(nextFetcher.parentJoinField);
-//                    // Store join values in multimap for
-//                    if (joinValue != null)
-//                        joinValuesForJoinField.put(nextFetcher.parentJoinField, joinValue.toString());
-//                }
-//            }
-//        }
-//        // Last iteration should finally return results.
-//        return null;
 
         JDBCFetcher lastFetcher = null;
         List<String> preparedStatementParameters = new ArrayList<>();
@@ -187,7 +134,8 @@ public class NestedJDBCFetcher implements DataFetcher<List<Map<String, Object>>>
             }
             lastFetcher = fetcher;
         }
-        // Last iteration should finally return results.
+        // This piece of code will never be reached because of how things get returned above.
+        // But it's here to make java happy.
         return new ArrayList<>();
     }
 

--- a/src/main/java/com/conveyal/gtfs/graphql/fetchers/NestedJDBCFetcher.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/fetchers/NestedJDBCFetcher.java
@@ -24,10 +24,10 @@ import static com.conveyal.gtfs.graphql.fetchers.JDBCFetcher.makeInClause;
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
 
 /**
- * This fetcher uses nested calls to the general JDBCFetcher for SQL data. It uses the parent entity and a series of
- * joins to leap frog from one entity to another more distantly-related entity. For example, if we want to know the
- * routes that serve a specific stop, starting with a top-level stop type, we can nest joins from stop ABC -> pattern
- * stops -> patterns -> routes (see below example implementation for more details).
+ * This fetcher creates one big query by joining tables in the order specified in the initial definition.  The data
+ * returned will only consist of the columns from the final table definition.  All other tables are assumed to be
+ * intermediate tables used to create joins to obtain filtered data from the final table.  Also, any grqphQL arguments
+ * are applied only to the final table.
  */
 public class NestedJDBCFetcher implements DataFetcher<Object> {
 
@@ -63,6 +63,11 @@ public class NestedJDBCFetcher implements DataFetcher<Object> {
                 .build();
     }
 
+    /**
+     * get the data for the nested query by making a sql query.  The sql query is constructed by adding tables to be
+     * queried and joining them via where clauses.  This ultimately returns a CompleteableFuture value that is
+     * executed by graphQL at some strategic point in time.
+     */
     @Override
     public Object get (DataFetchingEnvironment environment) {
         // GetSource is the context in which this this DataFetcher has been created, in this case a map representing

--- a/src/main/java/com/conveyal/gtfs/graphql/fetchers/RowCountFetcher.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/fetchers/RowCountFetcher.java
@@ -11,6 +11,7 @@ import org.apache.commons.dbutils.DbUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -57,12 +58,13 @@ public class RowCountFetcher implements DataFetcher {
     public Object get(DataFetchingEnvironment environment) {
         Map<String, Object> parentFeedMap = environment.getSource();
         Map<String, Object> arguments = environment.getArguments();
+        DataSource dataSource = GTFSGraphQL.getDataSourceFromContext(environment);
         List<String> argKeys = new ArrayList<>(arguments.keySet());
         List<String> parameters = new ArrayList<>();
         String namespace = (String) parentFeedMap.get("namespace");
         Connection connection = null;
         try {
-            connection = GTFSGraphQL.getConnection();
+            connection = dataSource.getConnection();
             List<String> fields = new ArrayList<>();
             fields.add("count(*)");
             List<String> clauses = new ArrayList<>();

--- a/src/main/java/com/conveyal/gtfs/graphql/fetchers/SQLColumnFetcher.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/fetchers/SQLColumnFetcher.java
@@ -73,13 +73,12 @@ public class SQLColumnFetcher<T> implements DataFetcher<List<T>> {
         try {
             connection = dataSource.getConnection();
             for (Map<String, Object> row : jdbcFetcher.getSqlQueryResult(
-                new JDBCFetcher.JdbcQuery(
-                    namespace,
-                    Arrays.asList(filterValue),
-                    sqlStatementBuilder.toString()
-                ),
-                connection
-            )) {
+                connection,
+                namespace,
+                sqlStatementBuilder.toString(),
+                Arrays.asList(filterValue)
+                )
+            ) {
                 results.add((T) row.get(columnName));
             }
         } catch (SQLException e) {

--- a/src/test/java/com/conveyal/gtfs/graphql/GTFSGraphQLTest.java
+++ b/src/test/java/com/conveyal/gtfs/graphql/GTFSGraphQLTest.java
@@ -75,74 +75,74 @@ public class GTFSGraphQLTest {
     }
 
     // tests that the graphQL schema can initialize
-    @Test
+    @Test(timeout=5000)
     public void canInitialize() {
         GTFSGraphQL.initialize(testDataSource);
         GraphQL graphQL = GTFSGraphQL.getGraphQl();
     }
 
     // tests that the root element of a feed can be fetched
-    @Test
+    @Test(timeout=5000)
     public void canFetchFeed() throws IOException {
         assertThat(queryGraphQL("feed.txt"), matchesSnapshot());
     }
 
     // tests that the row counts of a feed can be fetched
-    @Test
+    @Test(timeout=5000)
     public void canFetchFeedRowCounts() throws IOException {
         assertThat(queryGraphQL("feedRowCounts.txt"), matchesSnapshot());
     }
 
     // tests that the errors of a feed can be fetched
-    @Test
+    @Test(timeout=5000)
     public void canFetchErrors() throws IOException {
         assertThat(queryGraphQL("feedErrors.txt"), matchesSnapshot());
     }
 
     // tests that the feed_info of a feed can be fetched
-    @Test
+    @Test(timeout=5000)
     public void canFetchFeedInfo() throws IOException {
         assertThat(queryGraphQL("feedFeedInfo.txt"), matchesSnapshot());
     }
 
     // tests that the patterns of a feed can be fetched
-    @Test
+    @Test(timeout=5000)
     public void canFetchPatterns() throws IOException {
         assertThat(queryGraphQL("feedPatterns.txt"), matchesSnapshot());
     }
 
     // tests that the agencies of a feed can be fetched
-    @Test
+    @Test(timeout=5000)
     public void canFetchAgencies() throws IOException {
         assertThat(queryGraphQL("feedAgencies.txt"), matchesSnapshot());
     }
 
     // tests that the calendars of a feed can be fetched
-    @Test
+    @Test(timeout=5000)
     public void canFetchCalendars() throws IOException {
         assertThat(queryGraphQL("feedCalendars.txt"), matchesSnapshot());
     }
 
     // tests that the fares of a feed can be fetched
-    @Test
+    @Test(timeout=5000)
     public void canFetchFares() throws IOException {
         assertThat(queryGraphQL("feedFares.txt"), matchesSnapshot());
     }
 
     // tests that the routes of a feed can be fetched
-    @Test
+    @Test(timeout=5000)
     public void canFetchRoutes() throws IOException {
         assertThat(queryGraphQL("feedRoutes.txt"), matchesSnapshot());
     }
 
     // tests that the stops of a feed can be fetched
-    @Test
+    @Test(timeout=5000)
     public void canFetchStops() throws IOException {
         assertThat(queryGraphQL("feedStops.txt"), matchesSnapshot());
     }
 
     // tests that the trips of a feed can be fetched
-    @Test
+    @Test(timeout=5000)
     public void canFetchTrips() throws IOException {
         assertThat(queryGraphQL("feedTrips.txt"), matchesSnapshot());
     }
@@ -150,19 +150,19 @@ public class GTFSGraphQLTest {
     // TODO: make tests for schedule_exceptions / calendar_dates
 
     // tests that the stop times of a feed can be fetched
-    @Test
+    @Test(timeout=5000)
     public void canFetchStopTimes() throws IOException {
         assertThat(queryGraphQL("feedStopTimes.txt"), matchesSnapshot());
     }
 
     // tests that the stop times of a feed can be fetched
-    @Test
+    @Test(timeout=5000)
     public void canFetchServices() throws IOException {
         assertThat(queryGraphQL("feedServices.txt"), matchesSnapshot());
     }
 
     // tests that the stop times of a feed can be fetched
-    @Test
+    @Test(timeout=5000)
     public void canFetchRoutesAndFilterTripsByDateAndTime() throws IOException {
         Map<String, Object> variables = new HashMap<String, Object>();
         variables.put("namespace", testNamespace);
@@ -176,7 +176,7 @@ public class GTFSGraphQLTest {
     }
 
     // tests that the limit argument applies properly to a fetcher defined with autolimit set to false
-    @Test
+    @Test(timeout=5000)
     public void canFetchNestedEntityWithLimit() throws IOException {
         assertThat(queryGraphQL("feedStopsStopTimeLimit.txt"), matchesSnapshot());
     }
@@ -185,7 +185,7 @@ public class GTFSGraphQLTest {
      * attempt to fetch more than one record with SQL injection as inputs
      * the graphql library should properly escape the string and return 0 results for stops
      */
-    @Test
+    @Test(timeout=5000)
     public void canSanitizeSQLInjectionSentAsInput() throws IOException {
         Map<String, Object> variables = new HashMap<String, Object>();
         variables.put("namespace", testInjectionNamespace);
@@ -204,7 +204,7 @@ public class GTFSGraphQLTest {
      * attempt run a graphql query when one of the pieces of data contains a SQL injection
      * the graphql library should properly escape the string and complete the queries
      */
-    @Test
+    @Test(timeout=5000)
     public void canSanitizeSQLInjectionSentAsKeyValue() throws IOException, SQLException {
         // manually update the route_id key in routes and patterns
         String injection = "'' OR 1=1; Select ''99";

--- a/src/test/java/com/conveyal/gtfs/graphql/GTFSGraphQLTest.java
+++ b/src/test/java/com/conveyal/gtfs/graphql/GTFSGraphQLTest.java
@@ -177,10 +177,19 @@ public class GTFSGraphQLTest {
         assertThat(queryGraphQL("feedStopsStopTimeLimit.txt"), matchesSnapshot());
     }
 
-    // tests that the limit argument applies properly to a fetcher defined with autolimit set to false
+    // tests whether a graphQL query that has superflous and redundant nesting can find the right result
+    // if the graphQL dataloader is enabled correctly, there will not be any repeating sql queries in the logs
     @Test(timeout=5000)
     public void canFetchMultiNestedEntities() throws IOException {
         assertThat(queryGraphQL("superNested.txt"), matchesSnapshot());
+    }
+
+    // tests whether a graphQL query that has superflous and redundant nesting can find the right result
+    // if the graphQL dataloader is enabled correctly, there will not be any repeating sql queries in the logs
+    // furthermore, some queries should have been combined together
+    @Test(timeout=5000)
+    public void canFetchMultiNestedEntitiesWithoutLimits() throws IOException {
+        assertThat(queryGraphQL("superNestedNoLimits.txt"), matchesSnapshot());
     }
 
     /**

--- a/src/test/resources/graphql/superNested.txt
+++ b/src/test/resources/graphql/superNested.txt
@@ -1,0 +1,23 @@
+query ($namespace: String) {
+  feed(namespace: $namespace) {
+    feed_version
+    routes {
+      route_id
+      stops {
+        routes {
+          route_id
+          stops {
+            routes {
+              route_id
+              stops {
+                stop_id
+              }
+            }
+            stop_id
+          }
+        }
+        stop_id
+      }
+    }
+  }
+}

--- a/src/test/resources/graphql/superNestedNoLimits.txt
+++ b/src/test/resources/graphql/superNestedNoLimits.txt
@@ -1,0 +1,23 @@
+query ($namespace: String) {
+  feed(namespace: $namespace) {
+    feed_version
+    routes(limit: -1) {
+      route_id
+      stops(limit: -1) {
+        routes(limit: -1) {
+          route_id
+          stops(limit: -1) {
+            routes(limit: -1) {
+              route_id
+              stops(limit: -1) {
+                stop_id
+              }
+            }
+            stop_id
+          }
+        }
+        stop_id
+      }
+    }
+  }
+}

--- a/src/test/resources/snapshots/com/conveyal/gtfs/graphql/GTFSGraphQLTest/canFetchMultiNestedEntities.json
+++ b/src/test/resources/snapshots/com/conveyal/gtfs/graphql/GTFSGraphQLTest/canFetchMultiNestedEntities.json
@@ -1,0 +1,63 @@
+{
+  "data" : {
+    "feed" : {
+      "feed_version" : "1.0",
+      "routes" : [ {
+        "route_id" : "1",
+        "stops" : [ {
+          "routes" : [ {
+            "route_id" : "1",
+            "stops" : [ {
+              "routes" : [ {
+                "route_id" : "1",
+                "stops" : [ {
+                  "stop_id" : "4u6g"
+                }, {
+                  "stop_id" : "johv"
+                } ]
+              } ],
+              "stop_id" : "4u6g"
+            }, {
+              "routes" : [ {
+                "route_id" : "1",
+                "stops" : [ {
+                  "stop_id" : "4u6g"
+                }, {
+                  "stop_id" : "johv"
+                } ]
+              } ],
+              "stop_id" : "johv"
+            } ]
+          } ],
+          "stop_id" : "4u6g"
+        }, {
+          "routes" : [ {
+            "route_id" : "1",
+            "stops" : [ {
+              "routes" : [ {
+                "route_id" : "1",
+                "stops" : [ {
+                  "stop_id" : "4u6g"
+                }, {
+                  "stop_id" : "johv"
+                } ]
+              } ],
+              "stop_id" : "4u6g"
+            }, {
+              "routes" : [ {
+                "route_id" : "1",
+                "stops" : [ {
+                  "stop_id" : "4u6g"
+                }, {
+                  "stop_id" : "johv"
+                } ]
+              } ],
+              "stop_id" : "johv"
+            } ]
+          } ],
+          "stop_id" : "johv"
+        } ]
+      } ]
+    }
+  }
+}

--- a/src/test/resources/snapshots/com/conveyal/gtfs/graphql/GTFSGraphQLTest/canFetchMultiNestedEntitiesWithoutLimits.json
+++ b/src/test/resources/snapshots/com/conveyal/gtfs/graphql/GTFSGraphQLTest/canFetchMultiNestedEntitiesWithoutLimits.json
@@ -1,0 +1,63 @@
+{
+  "data" : {
+    "feed" : {
+      "feed_version" : "1.0",
+      "routes" : [ {
+        "route_id" : "1",
+        "stops" : [ {
+          "routes" : [ {
+            "route_id" : "1",
+            "stops" : [ {
+              "routes" : [ {
+                "route_id" : "1",
+                "stops" : [ {
+                  "stop_id" : "4u6g"
+                }, {
+                  "stop_id" : "johv"
+                } ]
+              } ],
+              "stop_id" : "4u6g"
+            }, {
+              "routes" : [ {
+                "route_id" : "1",
+                "stops" : [ {
+                  "stop_id" : "4u6g"
+                }, {
+                  "stop_id" : "johv"
+                } ]
+              } ],
+              "stop_id" : "johv"
+            } ]
+          } ],
+          "stop_id" : "4u6g"
+        }, {
+          "routes" : [ {
+            "route_id" : "1",
+            "stops" : [ {
+              "routes" : [ {
+                "route_id" : "1",
+                "stops" : [ {
+                  "stop_id" : "4u6g"
+                }, {
+                  "stop_id" : "johv"
+                } ]
+              } ],
+              "stop_id" : "4u6g"
+            }, {
+              "routes" : [ {
+                "route_id" : "1",
+                "stops" : [ {
+                  "stop_id" : "4u6g"
+                }, {
+                  "stop_id" : "johv"
+                } ]
+              } ],
+              "stop_id" : "johv"
+            } ]
+          } ],
+          "stop_id" : "johv"
+        } ]
+      } ]
+    }
+  }
+}


### PR DESCRIPTION
This PR is in response to issue #125. Its objective is to simplify and reduce the number of SQL queries generated to handle a single GraphQL query (i.e. this is an optimization which operates within a single GraphQL query; it does not cache or optimize across multiple GraphQL queries).

- Update graphql-java from version 4.2 to 10.0
- Refactor NestedJDBCFetcher to make queries with joins instead of numerous individual queries
- Add dataloader integration to batch queries and cache sql queries
- Refactor initialization of graphQL executions