### PR TITLE
Rename variable to avoid confusion

### DIFF
--- a/src/main/java/com/conveyal/gtfs/validator/ServiceValidator.java
+++ b/src/main/java/com/conveyal/gtfs/validator/ServiceValidator.java
@@ -185,8 +185,8 @@ public class ServiceValidator extends TripValidator {
                 if (date.isAfter(lastDate)) lastDate = date;
             }
             // Copy some useful information into the ValidationResult object to return to the caller.
-            validationResult.firstCalendarDate = firstDate;
-            validationResult.lastCalendarDate = lastDate;
+            validationResult.firstDateOfService = firstDate;
+            validationResult.lastDateOfService = lastDate;
             // Is this any different? firstDate.until(lastDate, ChronoUnit.DAYS);
             int nDays = (int) ChronoUnit.DAYS.between(firstDate, lastDate) + 1;
             validationResult.dailyBusSeconds = new int[nDays];

--- a/src/main/java/com/conveyal/gtfs/validator/ServiceValidator.java
+++ b/src/main/java/com/conveyal/gtfs/validator/ServiceValidator.java
@@ -185,8 +185,11 @@ public class ServiceValidator extends TripValidator {
                 if (date.isAfter(lastDate)) lastDate = date;
             }
             // Copy some useful information into the ValidationResult object to return to the caller.
-            validationResult.firstDateOfService = firstDate;
-            validationResult.lastDateOfService = lastDate;
+            // These variables are actually not directly tied to data in the calendar_dates.txt file.  Instead, they
+            // represent the first and last date respectively of any entry in the calendar.txt and calendar_dates.txt
+            // files.
+            validationResult.firstCalendarDate = firstDate;
+            validationResult.lastCalendarDate = lastDate;
             // Is this any different? firstDate.until(lastDate, ChronoUnit.DAYS);
             int nDays = (int) ChronoUnit.DAYS.between(firstDate, lastDate) + 1;
             validationResult.dailyBusSeconds = new int[nDays];

--- a/src/main/java/com/conveyal/gtfs/validator/ValidationResult.java
+++ b/src/main/java/com/conveyal/gtfs/validator/ValidationResult.java
@@ -1,13 +1,10 @@
 package com.conveyal.gtfs.validator;
 
-import java.awt.geom.Rectangle2D;
-import java.io.Serializable;
-import com.conveyal.gtfs.model.Pattern;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
+import java.awt.geom.Rectangle2D;
+import java.io.Serializable;
 import java.time.LocalDate;
-import java.util.List;
 
 /**
  * An instance of this class is returned by the validator.
@@ -26,8 +23,13 @@ public class ValidationResult implements Serializable {
     public int errorCount;
     public LocalDate declaredStartDate;
     public LocalDate declaredEndDate;
-    public LocalDate firstCalendarDate;
-    public LocalDate lastCalendarDate;
+
+    /**
+     * the actual first and last date of service which is calculated in {@link ServiceValidator#complete}
+     */
+    public LocalDate firstDateOfService;
+    public LocalDate lastDateOfService;
+
     public int[] dailyBusSeconds;
     public int[] dailyTramSeconds;
     public int[] dailyMetroSeconds;

--- a/src/main/java/com/conveyal/gtfs/validator/ValidationResult.java
+++ b/src/main/java/com/conveyal/gtfs/validator/ValidationResult.java
@@ -26,9 +26,11 @@ public class ValidationResult implements Serializable {
 
     /**
      * the actual first and last date of service which is calculated in {@link ServiceValidator#complete}
+     * These variables are actually not directly tied to data in the calendar_dates.txt file.  Instead, they represent
+     * the first and last date respectively of any entry in the calendar.txt and calendar_dates.txt files.
      */
-    public LocalDate firstDateOfService;
-    public LocalDate lastDateOfService;
+    public LocalDate firstCalendarDate;
+    public LocalDate lastCalendarDate;
 
     public int[] dailyBusSeconds;
     public int[] dailyTramSeconds;


### PR DESCRIPTION
At first, I thought the variables `firstCalendarDate` and `lastCalendarDate` in the `ValidationResult` class were the first calendar date from the calendar_dates.txt file, but then I realized it was actually a result of calculating actual service of various days.  Renaming this variable should reflect this distinction and avoid future confusion.