### PR TITLE
Remove small table indexing

### DIFF
--- a/src/main/java/com/conveyal/gtfs/GTFS.java
+++ b/src/main/java/com/conveyal/gtfs/GTFS.java
@@ -184,7 +184,7 @@ public abstract class GTFS {
         try {
             cmd = new DefaultParser().parse(options, args);
         } catch (ParseException e) {
-            LOG.error("Error parsing command line: " + e.getMessage());
+            LOG.error("Error parsing command line", e);
             printHelp(options);
             return;
         }

--- a/src/main/java/com/conveyal/gtfs/loader/Table.java
+++ b/src/main/java/com/conveyal/gtfs/loader/Table.java
@@ -695,6 +695,10 @@ public class Table {
      * FIXME: add foreign reference indexes?
      */
     public void createIndexes(Connection connection, String namespace) throws SQLException {
+        if ("agency".equals(name)) {
+            LOG.info("Skipping indexes for {} table", name);
+            return;
+        }
         LOG.info("Indexing...");
         String tableName;
         if (namespace == null) {

--- a/src/main/java/com/conveyal/gtfs/loader/Table.java
+++ b/src/main/java/com/conveyal/gtfs/loader/Table.java
@@ -696,6 +696,8 @@ public class Table {
      */
     public void createIndexes(Connection connection, String namespace) throws SQLException {
         if ("agency".equals(name)) {
+            // Skip indexing for the agency table, which usually has so few records that indexes are unlikely to
+            // improve query performance. NOTE: other tables could be added here in the future as needed.
             LOG.info("Skipping indexes for {} table", name);
             return;
         }

--- a/src/main/java/com/conveyal/gtfs/loader/Table.java
+++ b/src/main/java/com/conveyal/gtfs/loader/Table.java
@@ -695,13 +695,14 @@ public class Table {
      * FIXME: add foreign reference indexes?
      */
     public void createIndexes(Connection connection, String namespace) throws SQLException {
-        if ("agency".equals(name)) {
-            // Skip indexing for the agency table, which usually has so few records that indexes are unlikely to
-            // improve query performance. NOTE: other tables could be added here in the future as needed.
+        if ("agency".equals(name) || "feed_info".equals(name)) {
+            // Skip indexing for the small tables that have so few records that indexes are unlikely to
+            // improve query performance or that are unlikely to be joined to other tables. NOTE: other tables could be
+            // added here in the future as needed.
             LOG.info("Skipping indexes for {} table", name);
             return;
         }
-        LOG.info("Indexing...");
+        LOG.info("Indexing {}...", name);
         String tableName;
         if (namespace == null) {
             throw new IllegalStateException("Schema namespace must be provided!");


### PR DESCRIPTION
This removes indexing for a couple of small tables, namely `agency` and `feed_info`.

Fixes #132.