### PR TITLE
Add route_sort_order to graphql route_type fields

### DIFF
--- a/src/main/java/com/conveyal/gtfs/graphql/GraphQLGtfsSchema.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/GraphQLGtfsSchema.java
@@ -269,6 +269,7 @@ public class GraphQLGtfsSchema {
             .field(MapFetcher.field("wheelchair_accessible"))
             .field(MapFetcher.field("publicly_visible", GraphQLInt))
             .field(MapFetcher.field("status", GraphQLInt))
+            .field(MapFetcher.field("route_sort_order"))
             // FIXME ^^
             .field(RowCountFetcher.field("trip_count", "trips", "route_id"))
             .field(RowCountFetcher.field("pattern_count", "patterns", "route_id"))


### PR DESCRIPTION
The `route_sort_order` field was added to the routes table as a part of PR #99, but the field wasn't added to the GraphQL schema.  This PR fixes that.