### PR TITLE
Update to version 4.1.x of maven-semantic-release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,4 +65,4 @@ notifications:
 # Push results to codecov.io and run semantic-release (releases only created on pushes to the master branch).
 after_success:
   - bash <(curl -s https://codecov.io/bash)
-  - semantic-release --prepare @conveyal/maven-semantic-release --publish @semantic-release/github,@conveyal/maven-semantic-release --verify-conditions @semantic-release/github --verify-release @conveyal/maven-semantic-release --use-conveyal-workflow --dev-branch=dev
+  - semantic-release --prepare @conveyal/maven-semantic-release --publish @semantic-release/github,@conveyal/maven-semantic-release --verify-conditions @semantic-release/github,@conveyal/maven-semantic-release --verify-release @conveyal/maven-semantic-release --use-conveyal-workflow --dev-branch=dev


### PR DESCRIPTION
maven-semantic-release v4.1.x+ now includes a verify-conditions step that checks if the maven project seems to be setup to be able to release to maven central.