### PR TITLE
Update trip#shape_id and frequency stop_times on pattern updates

### DIFF
--- a/src/main/java/com/conveyal/gtfs/graphql/GraphQLGtfsSchema.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/GraphQLGtfsSchema.java
@@ -381,6 +381,7 @@ public class GraphQLGtfsSchema {
             .field(MapFetcher.field("shape_dist_traveled", GraphQLFloat))
             .field(MapFetcher.field("drop_off_type", GraphQLInt))
             .field(MapFetcher.field("pickup_type", GraphQLInt))
+            .field(MapFetcher.field("stop_sequence", GraphQLInt))
             .field(MapFetcher.field("timepoint", GraphQLInt))
             // FIXME: This will only returns a list with one stop entity (unless there is a referential integrity issue)
             // Should this be modified to be an object, rather than a list?
@@ -390,7 +391,6 @@ public class GraphQLGtfsSchema {
                     .dataFetcher(new JDBCFetcher("stops", "stop_id"))
                     .build()
             )
-            .field(MapFetcher.field("stop_sequence", GraphQLInt))
             .build();
 
     /**

--- a/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
+++ b/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
@@ -229,7 +229,13 @@ public class JdbcTableWriter implements TableWriter {
      * tables (for now just fields in trips and stop_times) where the reference table's value should take precedence over
      * the related table (e.g., pattern_stop#timepoint should update all of its related stop_times).
      */
-    private void updateLinkedFields(Table referenceTable, ObjectNode jsonObject, String tableName, String keyField, String ...fieldNames) throws SQLException {
+    private void updateLinkedFields(
+        Table referenceTable,
+        ObjectNode jsonObject,
+        String tableName,
+        String keyField,
+        String ...fieldNames
+    ) throws SQLException {
         boolean updatingStopTimes = "stop_times".equals(tableName);
         // Collect fields, the JSON values for these fields, and the strings to add to the prepared statement into Lists.
         List<Field> fields = new ArrayList<>();
@@ -283,7 +289,14 @@ public class JdbcTableWriter implements TableWriter {
      * object here is provided as a positional argument (rather than provided via the JdbcTableWriter instance field)
      * because this method is used to update both the specTable for the primary entity and any relevant child entities.
      */
-    private PreparedStatement createPreparedUpdate(Integer id, boolean isCreating, ObjectNode jsonObject, Table table, Connection connection, boolean batch) throws SQLException {
+    private PreparedStatement createPreparedUpdate(
+        Integer id,
+        boolean isCreating,
+        ObjectNode jsonObject,
+        Table table,
+        Connection connection,
+        boolean batch
+    ) throws SQLException {
         String statementString;
         if (isCreating) {
             statementString = table.generateInsertSql(tablePrefix, true);
@@ -306,7 +319,12 @@ public class JdbcTableWriter implements TableWriter {
      * taken from JSON. Note, string values are used here in order to take advantage of setParameter method on
      * individual fields, which handles parsing string and non-string values into the appropriate SQL field types.
      */
-    private void setStatementParameters(ObjectNode jsonObject, Table table, PreparedStatement preparedStatement, Connection connection) throws SQLException {
+    private void setStatementParameters(
+        ObjectNode jsonObject,
+        Table table,
+        PreparedStatement preparedStatement,
+        Connection connection
+    ) throws SQLException {
         // JDBC SQL statements use a one-based index for setting fields/parameters
         List<String> missingFieldNames = new ArrayList<>();
         int index = 1;
@@ -380,7 +398,13 @@ public class JdbcTableWriter implements TableWriter {
         }
         if (missingFieldNames.size() > 0) {
 //            String joinedFieldNames = missingFieldNames.stream().collect(Collectors.joining(", "));
-            throw new SQLException(String.format("The following field(s) are missing from JSON %s object: %s", table.name, missingFieldNames.toString()));
+            throw new SQLException(
+                String.format(
+                    "The following field(s) are missing from JSON %s object: %s",
+                    table.name,
+                    missingFieldNames.toString()
+                )
+            );
         }
     }
 
@@ -486,13 +510,15 @@ public class JdbcTableWriter implements TableWriter {
                 boolean orderIsUnique = orderValues.add(orderValue);
                 boolean valuesAreIncrementing = ++previousOrder == orderValue;
                 if (!orderIsUnique || !valuesAreIncrementing) {
-                    throw new SQLException(String.format(
+                    throw new SQLException(
+                        String.format(
                             "%s %s values must be zero-based, unique, and incrementing. Entity at index %d had %s value of %d",
                             subTable.name,
                             orderFieldName,
                             entityCount,
                             previousOrder == 0 ? "non-zero" : !valuesAreIncrementing ? "non-incrementing" : "duplicate",
-                            orderValue)
+                            orderValue
+                        )
                     );
                 }
             }
@@ -814,7 +840,13 @@ public class JdbcTableWriter implements TableWriter {
      * Check the stops in the changed region to ensure they remain in the same order. If not, throw an exception to
      * cancel the transaction.
      */
-    private static void verifyInteriorStopsAreUnchanged(List<String> originalStopIds, List<PatternStop> newStops, int firstDifferentIndex, int lastDifferentIndex, boolean movedRight) {
+    private static void verifyInteriorStopsAreUnchanged(
+        List<String> originalStopIds,
+        List<PatternStop> newStops,
+        int firstDifferentIndex,
+        int lastDifferentIndex,
+        boolean movedRight
+    ) {
         //Stops mapped to list of stop IDs simply for easier viewing/comparison with original IDs while debugging with
         // breakpoints.
         List<String> newStopIds = newStops.stream().map(s -> s.stop_id).collect(Collectors.toList());
@@ -839,7 +871,13 @@ public class JdbcTableWriter implements TableWriter {
      * You must call this method after updating sequences for any stop times following the starting stop sequence to
      * avoid overwriting these other stop times.
      */
-    private void insertBlankStopTimes(List<String> tripIds, List<PatternStop> newStops, int startingStopSequence, int stopTimesToAdd, Connection connection) throws SQLException {
+    private void insertBlankStopTimes(
+        List<String> tripIds,
+        List<PatternStop> newStops,
+        int startingStopSequence,
+        int stopTimesToAdd,
+        Connection connection
+    ) throws SQLException {
         if (tripIds.isEmpty()) {
             // There is no need to insert blank stop times if there are no trips for the pattern.
             return;
@@ -999,7 +1037,13 @@ public class JdbcTableWriter implements TableWriter {
      *
      * FIXME: add more detail/precise language on what this method actually does
      */
-    private static void ensureReferentialIntegrity(Connection connection, ObjectNode jsonObject, String namespace, Table table, Integer id) throws SQLException {
+    private static void ensureReferentialIntegrity(
+        Connection connection,
+        ObjectNode jsonObject,
+        String namespace,
+        Table table,
+        Integer id
+    ) throws SQLException {
         final boolean isCreating = id == null;
         String keyField = table.getKeyFieldName();
         String tableName = String.join(".", namespace, table.name);
@@ -1075,7 +1119,12 @@ public class JdbcTableWriter implements TableWriter {
     /**
      * For some condition (where field = string value), return the set of unique int IDs for the records that match.
      */
-    private static TIntSet getIdsForCondition(String tableName, String keyField, String keyValue, Connection connection) throws SQLException {
+    private static TIntSet getIdsForCondition(
+        String tableName,
+        String keyField,
+        String keyValue,
+        Connection connection
+    ) throws SQLException {
         String idCheckSql = String.format("select id from %s where %s = ?", tableName, keyField);
         // Create statement for counting rows selected
         PreparedStatement statement = connection.prepareStatement(idCheckSql);
@@ -1149,7 +1198,13 @@ public class JdbcTableWriter implements TableWriter {
      * not necessarily delete a shape that is shared by multiple trips)? I think not because we are skipping foreign refs
      * found in the table for the entity being updated/deleted. [Leaving this comment in place for now though.]
      */
-    private static void updateReferencingTables(String namespace, Table table, Connection connection, int id, String newKeyValue) throws SQLException {
+    private static void updateReferencingTables(
+        String namespace,
+        Table table,
+        Connection connection,
+        int id,
+        String newKeyValue
+    ) throws SQLException {
         Field keyField = table.getFieldForName(table.getKeyFieldName());
         Class<? extends Entity> entityClass = table.getEntityClass();
         // Determine method (update vs. delete) depending on presence of newKeyValue field.
@@ -1206,10 +1261,18 @@ public class JdbcTableWriter implements TableWriter {
                             if (table.isCascadeDeleteRestricted()) {
                                 // The entity must not have any referencing entities in order to delete it.
                                 connection.rollback();
-                                //                        List<String> idStrings = new ArrayList<>();
-                                //                        uniqueIds.forEach(uniqueId -> idStrings.add(String.valueOf(uniqueId)));
-                                //                        String message = String.format("Cannot delete %s %s=%s. %d %s reference this %s (%s).", entityClass.getSimpleName(), keyField, keyValue, result, referencingTable.name, entityClass.getSimpleName(), String.join(",", idStrings));
-                                String message = String.format("Cannot delete %s %s=%s. %d %s reference this %s.", entityClass.getSimpleName(), keyField.name, keyValue, result, referencingTable.name, entityClass.getSimpleName());
+                                // List<String> idStrings = new ArrayList<>();
+                                // uniqueIds.forEach(uniqueId -> idStrings.add(String.valueOf(uniqueId)));
+                                // String message = String.format("Cannot delete %s %s=%s. %d %s reference this %s (%s).", entityClass.getSimpleName(), keyField, keyValue, result, referencingTable.name, entityClass.getSimpleName(), String.join(",", idStrings));
+                                String message = String.format(
+                                    "Cannot delete %s %s=%s. %d %s reference this %s.",
+                                    entityClass.getSimpleName(),
+                                    keyField.name,
+                                    keyValue,
+                                    result,
+                                    referencingTable.name,
+                                    entityClass.getSimpleName()
+                                );
                                 LOG.warn(message);
                                 throw new SQLException(message);
                             }
@@ -1226,12 +1289,23 @@ public class JdbcTableWriter implements TableWriter {
     /**
      * Constructs SQL string based on method provided.
      */
-    private static String getUpdateReferencesSql(SqlMethod sqlMethod, String refTableName, Field keyField, String keyValue, String newKeyValue) throws SQLException {
+    private static String getUpdateReferencesSql(
+        SqlMethod sqlMethod,
+        String refTableName,
+        Field keyField,
+        String keyValue,
+        String newKeyValue
+    ) throws SQLException {
         boolean isArrayField = keyField.getSqlType().equals(JDBCType.ARRAY);
         switch (sqlMethod) {
             case DELETE:
                 if (isArrayField) {
-                    return String.format("delete from %s where %s @> ARRAY['%s']::text[]", refTableName, keyField.name, keyValue);
+                    return String.format(
+                        "delete from %s where %s @> ARRAY['%s']::text[]",
+                        refTableName,
+                        keyField.name,
+                        keyValue
+                    );
                 } else {
                     return String.format("delete from %s where %s = '%s'", refTableName, keyField.name, keyValue);
                 }
@@ -1240,9 +1314,25 @@ public class JdbcTableWriter implements TableWriter {
                     // If the field to be updated is an array field (of which there are only text[] types in the db),
                     // replace the old value with the new value using array contains clause.
                     // FIXME This is probably horribly postgres specific.
-                    return String.format("update %s set %s = array_replace(%s, '%s', '%s') where %s @> ARRAY['%s']::text[]", refTableName, keyField.name, keyField.name, keyValue, newKeyValue, keyField.name, keyValue);
+                    return String.format(
+                        "update %s set %s = array_replace(%s, '%s', '%s') where %s @> ARRAY['%s']::text[]",
+                        refTableName,
+                        keyField.name,
+                        keyField.name,
+                        keyValue,
+                        newKeyValue,
+                        keyField.name,
+                        keyValue
+                    );
                 } else {
-                    return String.format("update %s set %s = '%s' where %s = '%s'", refTableName, keyField.name, newKeyValue, keyField.name, keyValue);
+                    return String.format(
+                        "update %s set %s = '%s' where %s = '%s'",
+                        refTableName,
+                        keyField.name,
+                        newKeyValue,
+                        keyField.name,
+                        keyValue
+                    );
                 }
 //            case CREATE:
 //                return String.format("insert into %s ");

--- a/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
+++ b/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
@@ -428,7 +428,7 @@ public class JdbcTableWriter implements TableWriter {
      */
     private void updateChildTable(
         ArrayNode subEntities,
-        Integer id,
+        int id,
         boolean foreignReferenceIsFrequencyPattern,
         boolean isCreatingNewEntity,
         Table subTable,

--- a/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
+++ b/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
@@ -581,11 +581,9 @@ public class JdbcTableWriter implements TableWriter {
     private int updateStopTimesForPatternStop(ObjectNode patternStop, int previousTravelTime) throws SQLException {
         String sql = String.format(
             "update %s.stop_times st set arrival_time = ?, departure_time = ? from %s.trips t " +
-                "where st.trip_id = t.trip_id AND t.%s = ? AND st.%s = ?",
+                "where st.trip_id = t.trip_id AND t.pattern_id = ? AND st.stop_sequence = ?",
             tablePrefix,
-            tablePrefix,
-            "pattern_id",
-            "stop_sequence"
+            tablePrefix
         );
         // Prepare the statement and set statement parameters
         PreparedStatement statement = connection.prepareStatement(sql);

--- a/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
+++ b/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
@@ -169,10 +169,12 @@ public class JdbcTableWriter implements TableWriter {
                     int entityId = isCreating ? (int) newId : id;
                     // Cast child entities to array node to iterate over.
                     ArrayNode childEntitiesArray = (ArrayNode)childEntities;
+                    boolean foreignReferenceIsFrequencyPattern = jsonObject.has("use_frequency") &&
+                        jsonObject.get("use_frequency").asBoolean();
                     updateChildTable(
                         childEntitiesArray,
                         entityId,
-                        jsonObject.get("use_frequency").asBoolean(),
+                        foreignReferenceIsFrequencyPattern,
                         isCreating,
                         referencingTable,
                         connection

--- a/src/main/java/com/conveyal/gtfs/loader/Table.java
+++ b/src/main/java/com/conveyal/gtfs/loader/Table.java
@@ -163,6 +163,7 @@ public class Table {
         new ColorField("route_text_color",  OPTIONAL),
         // Editor fields below.
         new ShortField("publicly_visible", EDITOR, 1),
+        // wheelchair_accessible is an exemplar field applied to all trips on a route.
         new ShortField("wheelchair_accessible", EDITOR, 2).permitEmptyValue(),
         new IntegerField("route_sort_order", OPTIONAL, 0, Integer.MAX_VALUE),
         // Status values are In progress (0), Pending approval (1), and Approved (2).
@@ -196,7 +197,8 @@ public class Table {
             new StringField("pattern_id", REQUIRED),
             new StringField("route_id", REQUIRED).isReferenceTo(ROUTES),
             new StringField("name", OPTIONAL),
-            // Editor-specific fields
+            // Editor-specific fields.
+            // direction_id and shape_id are exemplar fields applied to all trips for a pattern.
             new ShortField("direction_id", EDITOR, 1),
             new ShortField("use_frequency", EDITOR, 1),
             new StringField("shape_id", EDITOR).isReferenceTo(SHAPES)

--- a/src/test/java/com/conveyal/gtfs/loader/JDBCTableWriterTest.java
+++ b/src/test/java/com/conveyal/gtfs/loader/JDBCTableWriterTest.java
@@ -411,7 +411,7 @@ public class JDBCTableWriterTest {
             true
         );
         LOG.info("deleted {} records from {}", deleteOutput, tripsTable.name);
-        // Check that route record does not exist in DB
+        // Check that record does not exist in DB
         assertThatSqlQueryYieldsZeroRows(
             String.format(
                 "select * from %s.%s where id=%d",

--- a/src/test/java/com/conveyal/gtfs/loader/JDBCTableWriterTest.java
+++ b/src/test/java/com/conveyal/gtfs/loader/JDBCTableWriterTest.java
@@ -375,7 +375,7 @@ public class JDBCTableWriterTest {
      * which is a prerequisite for creating a frequency trip with stop times.
      */
     @Test
-    public void canCreateFrequencyForFrequencyPattern() throws IOException, SQLException, InvalidNamespaceException {
+    public void canCreateUpdateAndDeleteFrequencyTripForFrequencyPattern() throws IOException, SQLException, InvalidNamespaceException {
         // Store Table and Class values for use in test.
         final Table tripsTable = Table.TRIPS;
         int startTime = 6 * 60 * 60;

--- a/src/test/java/com/conveyal/gtfs/loader/JDBCTableWriterTest.java
+++ b/src/test/java/com/conveyal/gtfs/loader/JDBCTableWriterTest.java
@@ -374,13 +374,16 @@ public class JDBCTableWriterTest {
         String routeId = "700";
         String patternId = UUID.randomUUID().toString();
         PatternDTO createdPattern = createSimpleRouteAndPattern(routeId, patternId, "The Loop");
-        // Update pattern with pattern stops and TODO shape points
+        // TODO Test that a frequency trip entry cannot be added for a timetable-based pattern.
+        // Update pattern with pattern stops, set to use frequencies, and TODO shape points
         JdbcTableWriter patternUpdater = createTestTableWriter(Table.PATTERNS);
+        createdPattern.use_frequency = 1;
         createdPattern.pattern_stops = new PatternStopDTO[]{
             new PatternStopDTO(patternId, firstStopId, 0),
             new PatternStopDTO(patternId, lastStopId, 1)
         };
-        patternUpdater.update(createdPattern.id, mapper.writeValueAsString(createdPattern), true);
+        String updatedPatternOutput = patternUpdater.update(createdPattern.id, mapper.writeValueAsString(createdPattern), true);
+        LOG.info("Updated pattern output: {}", updatedPatternOutput);
         // Create new trip for the pattern
         JdbcTableWriter createTripWriter = createTestTableWriter(tripsTable);
         TripDTO tripInput = new TripDTO();
@@ -391,8 +394,6 @@ public class JDBCTableWriterTest {
             new StopTimeDTO(firstStopId, 0, 0, 0),
             new StopTimeDTO(lastStopId, 60, 60, 1)
         };
-        // FIXME: Adding a frequency entry to this trip should not be permitted because the pattern has useFrequency set
-        //  to false (0).
         FrequencyDTO frequency = new FrequencyDTO();
         int startTime = 6 * 60 * 60;
         frequency.start_time = startTime;

--- a/src/test/java/com/conveyal/gtfs/util/CalendarDTO.java
+++ b/src/test/java/com/conveyal/gtfs/util/CalendarDTO.java
@@ -1,0 +1,16 @@
+package com.conveyal.gtfs.util;
+
+public class CalendarDTO {
+    public Integer id;
+    public String service_id;
+    public Integer monday;
+    public Integer tuesday;
+    public Integer wednesday;
+    public Integer thursday;
+    public Integer friday;
+    public Integer saturday;
+    public Integer sunday;
+    public String start_date;
+    public String end_date;
+    public String description;
+}

--- a/src/test/java/com/conveyal/gtfs/util/FrequencyDTO.java
+++ b/src/test/java/com/conveyal/gtfs/util/FrequencyDTO.java
@@ -1,0 +1,9 @@
+package com.conveyal.gtfs.util;
+
+public class FrequencyDTO {
+    public String trip_id;
+    public Integer start_time;
+    public Integer end_time;
+    public Integer headway_secs;
+    public Integer exact_times;
+}

--- a/src/test/java/com/conveyal/gtfs/util/PatternDTO.java
+++ b/src/test/java/com/conveyal/gtfs/util/PatternDTO.java
@@ -1,0 +1,13 @@
+package com.conveyal.gtfs.util;
+
+public class PatternDTO {
+    public Integer id;
+    public String pattern_id;
+    public String shape_id;
+    public String route_id;
+    public Integer direction_id;
+    public Integer use_frequency;
+    public String name;
+    public PatternStopDTO[] pattern_stops;
+    public ShapePointDTO[] shapes;
+}

--- a/src/test/java/com/conveyal/gtfs/util/PatternStopDTO.java
+++ b/src/test/java/com/conveyal/gtfs/util/PatternStopDTO.java
@@ -1,0 +1,20 @@
+package com.conveyal.gtfs.util;
+
+public class PatternStopDTO {
+    public Integer id;
+    public String pattern_id;
+    public String stop_id;
+    public Integer default_travel_time;
+    public Integer default_dwell_time;
+    public Double shape_dist_traveled;
+    public Integer drop_off_type;
+    public Integer pickup_type;
+    public Integer stop_sequence;
+    public Integer timepoint;
+
+    public PatternStopDTO (String patternId, String stopId, int stopSequence) {
+        pattern_id = patternId;
+        stop_id = stopId;
+        stop_sequence = stopSequence;
+    }
+}

--- a/src/test/java/com/conveyal/gtfs/util/ShapePointDTO.java
+++ b/src/test/java/com/conveyal/gtfs/util/ShapePointDTO.java
@@ -1,0 +1,6 @@
+package com.conveyal.gtfs.util;
+
+// TODO add fields
+public class ShapePointDTO {
+
+}

--- a/src/test/java/com/conveyal/gtfs/util/StopDTO.java
+++ b/src/test/java/com/conveyal/gtfs/util/StopDTO.java
@@ -1,0 +1,17 @@
+package com.conveyal.gtfs.util;
+
+public class StopDTO {
+    public Integer id;
+    public String stop_id;
+    public String stop_name;
+    public String stop_code;
+    public String stop_desc;
+    public Double stop_lon;
+    public Double stop_lat;
+    public String zone_id;
+    public String stop_url;
+    public String stop_timezone;
+    public String parent_station;
+    public Integer location_type;
+    public Integer wheelchair_boarding;
+}

--- a/src/test/java/com/conveyal/gtfs/util/StopTimeDTO.java
+++ b/src/test/java/com/conveyal/gtfs/util/StopTimeDTO.java
@@ -1,0 +1,26 @@
+package com.conveyal.gtfs.util;
+
+public class StopTimeDTO {
+    public String trip_id;
+    public String stop_id;
+    public Integer stop_sequence;
+    public Integer arrival_time;
+    public Integer departure_time;
+    public String stop_headsign;
+    public Integer timepoint;
+    public Integer drop_off_type;
+    public Integer pickup_type;
+    public Double shape_dist_traveled;
+
+    /**
+     * Empty constructor for deserialization
+     */
+    public StopTimeDTO () {}
+
+    public StopTimeDTO (String stopId, Integer arrivalTime, Integer departureTime, Integer stopSequence) {
+        stop_id = stopId;
+        arrival_time = arrivalTime;
+        departure_time = departureTime;
+        stop_sequence = stopSequence;
+    }
+}

--- a/src/test/java/com/conveyal/gtfs/util/TripDTO.java
+++ b/src/test/java/com/conveyal/gtfs/util/TripDTO.java
@@ -1,0 +1,18 @@
+package com.conveyal.gtfs.util;
+
+public class TripDTO {
+    public Integer id;
+    public String trip_id;
+    public String trip_headsign;
+    public String trip_short_name;
+    public String block_id;
+    public Integer direction_id;
+    public String route_id;
+    public String service_id;
+    public Integer wheelchair_accessible;
+    public Integer bikes_allowed;
+    public String shape_id;
+    public String pattern_id;
+    public StopTimeDTO[] stop_times;
+    public FrequencyDTO[] frequencies;
+}

--- a/src/test/java/com/conveyal/gtfs/util/UtilTest.java
+++ b/src/test/java/com/conveyal/gtfs/util/UtilTest.java
@@ -15,8 +15,11 @@ import static org.junit.Assert.fail;
  */
 public class UtilTest {
 
-    @Before // setup()
-    public void before() throws Exception {
+    /**
+     * Ensure locale (for {@link #canHumanize()}) is set correctly before doing anything else.
+     */
+    @Before
+    public void before() {
         java.util.Locale.setDefault(java.util.Locale.US);
     }
 


### PR DESCRIPTION
In addition to some formatting tweaks and added comments, this seeks to address the underlying cause for conveyal/datatools-ui#385. It is another example of updates for "exemplar" fields not making their way back to the referencing entities (#109).

It also fixes #165, where stop_time arrivals and departures were not kept in sync with updates to the underlying pattern travel times. This is only a concern with frequency-based patterns, but the same method could potentially be utilized for updating travel times in timetable-based trips if needed in the future.

Finally, it adds some tests to `JdbcTableWriter` for creating frequency trips and fixes #173, which was discovered in the process of writing these tests.