### PR TITLE
Validate stop_time#shape_dist_traveled

### DIFF
--- a/src/main/java/com/conveyal/gtfs/model/StopTime.java
+++ b/src/main/java/com/conveyal/gtfs/model/StopTime.java
@@ -26,7 +26,7 @@ public class StopTime extends Entity implements Cloneable, Serializable {
     public String stop_headsign;
     public int    pickup_type;
     public int    drop_off_type;
-    public double shape_dist_traveled;
+    public double shape_dist_traveled = DOUBLE_MISSING;
     public int    timepoint = INT_MISSING;
 
     @Override


### PR DESCRIPTION
We were missing a check for this field. It's relatively easy to check and I think it makes some sense to place this in the `SpeedTripValidator`. Fixes #163.