### PR TITLE
Run codecov after semantic-release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,5 +64,5 @@ notifications:
 
 # Push results to codecov.io and run semantic-release (releases only created on pushes to the master branch).
 after_success:
-  - bash <(curl -s https://codecov.io/bash)
   - semantic-release --prepare @conveyal/maven-semantic-release --publish @semantic-release/github,@conveyal/maven-semantic-release --verify-conditions @semantic-release/github,@conveyal/maven-semantic-release --verify-release @conveyal/maven-semantic-release --use-conveyal-workflow --dev-branch=dev
+  - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,4 +65,6 @@ notifications:
 # Push results to codecov.io and run semantic-release (releases only created on pushes to the master branch).
 after_success:
   - semantic-release --prepare @conveyal/maven-semantic-release --publish @semantic-release/github,@conveyal/maven-semantic-release --verify-conditions @semantic-release/github,@conveyal/maven-semantic-release --verify-release @conveyal/maven-semantic-release --use-conveyal-workflow --dev-branch=dev
+  # run codecov after semantic-release because maven-semantic-release creates extra commits that
+  # codecov will need a report on to reference in future PRs to the release branch
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
This way it will upload a report for the code coverage after all the commits made with maven-semantic-release have completed.  Codecov looks at the most recent commit to master to compare the next report to, so this is needed for code coverage comparisons on PRs to master.