### PR TITLE
Fix missing double in EntityPopulator

### DIFF
--- a/src/main/java/com/conveyal/gtfs/loader/EntityPopulator.java
+++ b/src/main/java/com/conveyal/gtfs/loader/EntityPopulator.java
@@ -262,7 +262,7 @@ public interface EntityPopulator<T> {
         double doubleValue = resultSet.getDouble(columnIndex);
         // If SQL value for column was null, resultSet.getDouble will return 0.0. If this is the case, override value with
         // DOUBLE_MISSING.
-        if (resultSet.wasNull()) return Entity.INT_MISSING;
+        if (resultSet.wasNull()) return Entity.DOUBLE_MISSING;
         else return doubleValue;
     }
 

--- a/src/main/java/com/conveyal/gtfs/loader/EntityPopulator.java
+++ b/src/main/java/com/conveyal/gtfs/loader/EntityPopulator.java
@@ -258,9 +258,12 @@ public interface EntityPopulator<T> {
     static double getDoubleIfPresent (ResultSet resultSet, String columnName,
                                              TObjectIntMap<String> columnForName) throws SQLException {
         int columnIndex = columnForName.get(columnName);
-        // FIXME: if SQL value is null, resultSet.getInt will return 0. Should return value equal 0 if column is missing?
         if (columnIndex == 0) return Entity.DOUBLE_MISSING;
-        else return resultSet.getDouble(columnIndex);
+        double doubleValue = resultSet.getDouble(columnIndex);
+        // If SQL value for column was null, resultSet.getDouble will return 0.0. If this is the case, override value with
+        // DOUBLE_MISSING.
+        if (resultSet.wasNull()) return Entity.INT_MISSING;
+        else return doubleValue;
     }
 
     static int getIntIfPresent (ResultSet resultSet, String columnName,


### PR DESCRIPTION
This PR fixes #180. In the EntityPopulator, which grabs data from the RDBMS and populates the GTFS entity Java objects, missing values for fields of the double type where populating as `0.0` rather than `Entity.DOUBLE_MISSING`. This was causing our validation check for increasing stop_time#shape_dist_traveled values to cause issues where these values were entirely missing from a GTFS feed.