### PR TITLE
After success refactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,19 +64,20 @@ notifications:
 
 # Push results to codecov.io and run semantic-release (releases only created on pushes to the master branch).
 after_success:
-  - semantic-release --prepare @conveyal/maven-semantic-release --publish @semantic-release/github,@conveyal/maven-semantic-release --verify-conditions @semantic-release/github,@conveyal/maven-semantic-release --verify-release @conveyal/maven-semantic-release --use-conveyal-workflow --dev-branch=dev
-  # run codecov after semantic-release because maven-semantic-release creates extra commits that
-  # codecov will need a report on to reference in future PRs to the release branch
   # this first codecov run will upload a report associated with the commit set through Travis CI environment variables
   - bash <(curl -s https://codecov.io/bash)
-  # Since the above codecov run is associated with the commit that initiated the Travis build, the report will not be
-  # associated with the commits that maven-semantic-release performed (if it ended up creating a release and the two
-  # commits that were a part of that workflow). Therefore, if on master codecov needs to be ran two more times to create
-  # codecov reports for the commits made by maven-semantic-release.
+  # run maven-semantic-release to potentially create a new release of gtfs-lib.
+  #
+  # If maven-semantic-release finishes successfully and the current branch is master, upload coverage reports for the
+  # commits that maven-semantic-release generated. Since the above codecov run is associated with the commit that
+  # initiated the Travis build, the report will not be associated with the commits that maven-semantic-release performed
+  # (if it ended up creating a release and the two commits that were a part of that workflow). Therefore, if on master
+  # codecov needs to be ran two more times to create codecov reports for the commits made by maven-semantic-release.
   # See https://github.com/conveyal/gtfs-lib/issues/193.
   #
   # The git commands get the commit hash of the HEAD commit and the commit just before HEAD.
   - |
+    semantic-release --prepare @conveyal/maven-semantic-release --publish @semantic-release/github,@conveyal/maven-semantic-release --verify-conditions @semantic-release/github,@conveyal/maven-semantic-release --verify-release @conveyal/maven-semantic-release --use-conveyal-workflow --dev-branch=dev
     if [[ "$TRAVIS_BRANCH" = "master" ]]; then
       bash <(curl -s https://codecov.io/bash) -C "$(git rev-parse HEAD)"
       bash <(curl -s https://codecov.io/bash) -C "$(git rev-parse HEAD^)"


### PR DESCRIPTION
In the latest merge to master, maven-semantic-release [failed during the Travis CI build](https://search.maven.org/solrsearch/select?q=com.conveyal.gtfs-lib&rows=20&wt=json). It looks like there was a poor internet connection. The build could probably just be reran and the internet will work again. However, there was an additional problem in that codecov reports were still uploaded for previous commits that were actually intended to be for commits from maven-semantic-release. This PR intends to run these extra codecov commands in the same script block so they won't be ran if maven-semantic-release fails.