### PR TITLE
Refactor field validation in order to store/validate bad values properly

### DIFF
--- a/src/main/java/com/conveyal/gtfs/error/NewGTFSError.java
+++ b/src/main/java/com/conveyal/gtfs/error/NewGTFSError.java
@@ -17,7 +17,7 @@ import java.util.Map;
 public class NewGTFSError {
 
     /** The class of the table in which the error was encountered. */
-    public final Class<? extends Entity> entityType;
+    public Class<? extends Entity> entityType;
 
     /** The kind of error encountered. */
     public final NewGTFSErrorType errorType;

--- a/src/main/java/com/conveyal/gtfs/error/NewGTFSErrorType.java
+++ b/src/main/java/com/conveyal/gtfs/error/NewGTFSErrorType.java
@@ -10,6 +10,7 @@ public enum NewGTFSErrorType {
     TIME_FORMAT(Priority.MEDIUM, "Time format should be HH:MM:SS."),
     URL_FORMAT(Priority.MEDIUM, "URL format should be <scheme>://<authority><path>?<query>#<fragment>"),
     LANGUAGE_FORMAT(Priority.LOW, "Language should be specified with a valid BCP47 tag."),
+    ILLEGAL_FIELD_VALUE(Priority.MEDIUM, "Fields may not contain tabs, carriage returns or new lines."),
     INTEGER_FORMAT(Priority.MEDIUM, "Incorrect integer format."),
     FLOATING_FORMAT(Priority.MEDIUM, "Incorrect floating point number format."),
     COLUMN_NAME_UNSAFE(Priority.HIGH, "Column header contains characters not safe in SQL, it was renamed."),

--- a/src/main/java/com/conveyal/gtfs/loader/BooleanField.java
+++ b/src/main/java/com/conveyal/gtfs/loader/BooleanField.java
@@ -1,11 +1,13 @@
 package com.conveyal.gtfs.loader;
 
+import com.conveyal.gtfs.error.NewGTFSError;
 import com.conveyal.gtfs.error.NewGTFSErrorType;
 import com.conveyal.gtfs.storage.StorageException;
 
 import java.sql.JDBCType;
 import java.sql.PreparedStatement;
 import java.sql.SQLType;
+import java.util.Set;
 
 /**
  * A GTFS boolean field, coded as a single character string 0 or 1.
@@ -17,17 +19,21 @@ public class BooleanField extends Field {
         super(name, requirement);
     }
 
-    private boolean validate (String string) {
+    private ValidateFieldResult<Boolean> validate (String string) {
+        ValidateFieldResult<Boolean> result = new ValidateFieldResult<>();
         if ( ! ("0".equals(string) || "1".equals(string))) {
-            throw new StorageException(NewGTFSErrorType.BOOLEAN_FORMAT, string);
+            result.errors.add(NewGTFSError.forFeed(NewGTFSErrorType.BOOLEAN_FORMAT, string));
         }
-        return "1".equals(string);
+        result.clean = "1".equals(string);
+        return result;
     }
 
     @Override
-    public void setParameter (PreparedStatement preparedStatement, int oneBasedIndex, String string) {
+    public Set<NewGTFSError> setParameter (PreparedStatement preparedStatement, int oneBasedIndex, String string) {
         try {
-            preparedStatement.setBoolean(oneBasedIndex, validate(string));
+            ValidateFieldResult<Boolean> result = validate(string);
+            preparedStatement.setBoolean(oneBasedIndex, result.clean);
+            return result.errors;
         } catch (Exception ex) {
             throw new StorageException(ex);
         }
@@ -37,8 +43,8 @@ public class BooleanField extends Field {
      * The 0 or 1 will be converted to the string "true" or "false" for SQL COPY.
      */
     @Override
-    public String validateAndConvert (String string) {
-        return Boolean.toString(validate(string));
+    public ValidateFieldResult<String> validateAndConvert (String string) {
+        return ValidateFieldResult.from(validate(string));
     }
 
     @Override

--- a/src/main/java/com/conveyal/gtfs/loader/DateListField.java
+++ b/src/main/java/com/conveyal/gtfs/loader/DateListField.java
@@ -1,5 +1,6 @@
 package com.conveyal.gtfs.loader;
 
+import com.conveyal.gtfs.error.NewGTFSError;
 import com.conveyal.gtfs.storage.StorageException;
 
 import java.sql.Array;
@@ -7,9 +8,8 @@ import java.sql.JDBCType;
 import java.sql.PreparedStatement;
 import java.sql.SQLType;
 import java.util.Arrays;
-import java.util.stream.Collectors;
-
-import static com.conveyal.gtfs.loader.DateField.validate;
+import java.util.Collections;
+import java.util.Set;
 
 public class DateListField extends Field {
 
@@ -18,19 +18,22 @@ public class DateListField extends Field {
     }
 
     @Override
-    public String validateAndConvert(String original) {
-        // FIXME
+    public ValidateFieldResult<String> validateAndConvert(String original) {
+        // FIXME: This function is currently only used during feed loading. Because the DateListField only exists for the
+        //  schedule exceptions table (which is not a GTFS spec table), we do not expect to ever call this function on
+        //  this table/field.
         return null;
     }
 
     @Override
-    public void setParameter(PreparedStatement preparedStatement, int oneBasedIndex, String string) {
+    public Set<NewGTFSError> setParameter(PreparedStatement preparedStatement, int oneBasedIndex, String string) {
         try {
             String[] dateStrings = Arrays.stream(string.split(","))
                     .map(DateField::validate)
                     .toArray(String[]::new);
             Array array = preparedStatement.getConnection().createArrayOf("text", dateStrings);
             preparedStatement.setArray(oneBasedIndex, array);
+            return Collections.EMPTY_SET;
         } catch (Exception ex) {
             throw new StorageException(ex);
         }

--- a/src/main/java/com/conveyal/gtfs/loader/DateListField.java
+++ b/src/main/java/com/conveyal/gtfs/loader/DateListField.java
@@ -11,6 +11,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;
 
+/**
+ * Field type for a list of date strings. This type is ONLY used for the editor-specific schedule exceptions table, so
+ * not all methods are supported (e.g., validateAndConvert has no functionality because it is only called on GTFS tables).
+ */
 public class DateListField extends Field {
 
     public DateListField(String name, Requirement requirement) {
@@ -19,10 +23,11 @@ public class DateListField extends Field {
 
     @Override
     public ValidateFieldResult<String> validateAndConvert(String original) {
-        // FIXME: This function is currently only used during feed loading. Because the DateListField only exists for the
-        //  schedule exceptions table (which is not a GTFS spec table), we do not expect to ever call this function on
-        //  this table/field.
-        return null;
+        // This function is currently only used during feed loading. Because the DateListField only exists for the
+        // schedule exceptions table (which is not a GTFS spec table), we do not expect to ever call this function on
+        // this table/field.
+        // TODO: is there any reason we may want to add support for validation?
+        throw new UnsupportedOperationException("Cannot call validateAndConvert on field of type DateListField because this is not a supported GTFS field type.");
     }
 
     @Override

--- a/src/main/java/com/conveyal/gtfs/loader/Field.java
+++ b/src/main/java/com/conveyal/gtfs/loader/Field.java
@@ -32,10 +32,10 @@ public abstract class Field {
      *
      * TODO: Add other illegal character sequences (e.g., HTML tags, comments or escape sequences).
      */
-    private static final Set<IllegalCharacter> ILLEGAL_CHARACTERS = ImmutableSet.of(
+    public static final Set<IllegalCharacter> ILLEGAL_CHARACTERS = ImmutableSet.of(
         // Backslashes, newlines, and tabs have special meaning to Postgres. Also, new lines, tabs, and carriage returns are
         // prohibited by GTFS.
-        new IllegalCharacter("\\", "\\\\", "Double slash"),
+        new IllegalCharacter("\\", "\\\\", "Unescaped backslash"),
         new IllegalCharacter("\t", " ", "Tab"),
         new IllegalCharacter("\n", " ", "New line"),
         new IllegalCharacter("\r", " ", "Carriage return")

--- a/src/main/java/com/conveyal/gtfs/loader/IllegalCharacter.java
+++ b/src/main/java/com/conveyal/gtfs/loader/IllegalCharacter.java
@@ -1,0 +1,18 @@
+package com.conveyal.gtfs.loader;
+
+/**
+ * This class contains a convenient way to describe illegal character sequences during GTFS feed loading, as well as the
+ * appropriate replacement value and a human-readable description (rather than inputting the bad sequence into the
+ * database and having to deal with downstream issues).
+ */
+public class IllegalCharacter {
+    public String illegalSequence;
+    public String replacement;
+    public String description;
+
+    public IllegalCharacter(String illegalSequence, String replacement, String description) {
+        this.illegalSequence = illegalSequence;
+        this.replacement = replacement;
+        this.description = description;
+    }
+}

--- a/src/main/java/com/conveyal/gtfs/loader/JdbcGtfsLoader.java
+++ b/src/main/java/com/conveyal/gtfs/loader/JdbcGtfsLoader.java
@@ -386,7 +386,7 @@ public class JdbcGtfsLoader {
                 String string = csvReader.get(f);
                 // Use spec table to check that references are valid and IDs are unique.
                 Set<NewGTFSError> errors = table.checkReferencesAndUniqueness(keyValue, lineNumber, field, string, referenceTracker);
-                // Check for special case with calendar_dates where addedd service should not trigger ref. integrity
+                // Check for special case with calendar_dates where added service should not trigger ref. integrity
                 // error.
                 if (
                     table.name.equals("calendar_dates") &&

--- a/src/main/java/com/conveyal/gtfs/loader/StringField.java
+++ b/src/main/java/com/conveyal/gtfs/loader/StringField.java
@@ -1,10 +1,12 @@
 package com.conveyal.gtfs.loader;
 
+import com.conveyal.gtfs.error.NewGTFSError;
 import com.conveyal.gtfs.storage.StorageException;
 
 import java.sql.JDBCType;
 import java.sql.PreparedStatement;
 import java.sql.SQLType;
+import java.util.Set;
 
 /**
  * Created by abyrd on 2017-03-31
@@ -16,13 +18,15 @@ public class StringField extends Field {
     }
 
     /** Check that a string can be properly parsed and is in range. */
-    public String validateAndConvert (String string) {
+    public ValidateFieldResult validateAndConvert (String string) {
         return cleanString(string);
     }
 
-    public void setParameter(PreparedStatement preparedStatement, int oneBasedIndex, String string) {
+    public Set<NewGTFSError> setParameter(PreparedStatement preparedStatement, int oneBasedIndex, String string) {
         try {
-            preparedStatement.setString(oneBasedIndex, validateAndConvert(string));
+            ValidateFieldResult<String> result = validateAndConvert(string);
+            preparedStatement.setString(oneBasedIndex, result.clean);
+            return result.errors;
         } catch (Exception ex) {
             throw new StorageException(ex);
         }

--- a/src/main/java/com/conveyal/gtfs/loader/StringField.java
+++ b/src/main/java/com/conveyal/gtfs/loader/StringField.java
@@ -18,7 +18,7 @@ public class StringField extends Field {
     }
 
     /** Check that a string can be properly parsed and is in range. */
-    public ValidateFieldResult validateAndConvert (String string) {
+    public ValidateFieldResult<String> validateAndConvert (String string) {
         return cleanString(string);
     }
 

--- a/src/main/java/com/conveyal/gtfs/loader/StringListField.java
+++ b/src/main/java/com/conveyal/gtfs/loader/StringListField.java
@@ -1,11 +1,14 @@
 package com.conveyal.gtfs.loader;
 
+import com.conveyal.gtfs.error.NewGTFSError;
 import com.conveyal.gtfs.storage.StorageException;
 
 import java.sql.Array;
 import java.sql.JDBCType;
 import java.sql.PreparedStatement;
 import java.sql.SQLType;
+import java.util.Collections;
+import java.util.Set;
 
 public class StringListField extends Field {
 
@@ -14,17 +17,20 @@ public class StringListField extends Field {
     }
 
     @Override
-    public String validateAndConvert(String original) {
-        // FIXME
+    public ValidateFieldResult<String> validateAndConvert(String original) {
+        // FIXME: This function is currently only used during feed loading. Because the StringListField only exists for the
+        //  schedule exceptions table (which is not a GTFS spec table), we do not expect to ever call this function on
+        //  this table/field.
         return null;
     }
 
     @Override
-    public void setParameter(PreparedStatement preparedStatement, int oneBasedIndex, String string) {
+    public Set<NewGTFSError> setParameter(PreparedStatement preparedStatement, int oneBasedIndex, String string) {
         // FIXME
         try {
             Array array = preparedStatement.getConnection().createArrayOf("text", string.split(","));
             preparedStatement.setArray(oneBasedIndex, array);
+            return Collections.EMPTY_SET;
         } catch (Exception e) {
             throw new StorageException(e);
         }

--- a/src/main/java/com/conveyal/gtfs/loader/StringListField.java
+++ b/src/main/java/com/conveyal/gtfs/loader/StringListField.java
@@ -10,6 +10,11 @@ import java.sql.SQLType;
 import java.util.Collections;
 import java.util.Set;
 
+/**
+ * Field type for a list of strings. This type is ONLY used for the storage of fare rules (i.e., the field type is not
+ * found or expected in CSV tables, so not all methods are supported (e.g., validateAndConvert has no functionality
+ * because it is only called on GTFS tables).
+ */
 public class StringListField extends Field {
 
     public StringListField(String name, Requirement requirement) {
@@ -18,10 +23,11 @@ public class StringListField extends Field {
 
     @Override
     public ValidateFieldResult<String> validateAndConvert(String original) {
-        // FIXME: This function is currently only used during feed loading. Because the StringListField only exists for the
-        //  schedule exceptions table (which is not a GTFS spec table), we do not expect to ever call this function on
-        //  this table/field.
-        return null;
+        // This function is currently only used during feed loading. Because the StringListField only exists for the
+        // schedule exceptions table (which is not a GTFS spec table), we do not expect to ever call this function on
+        // this table/field.
+        // TODO: is there any reason we may want to add support for validation?
+        throw new UnsupportedOperationException("Cannot call validateAndConvert on field of type StringListField because this is not a supported GTFS field type.");
     }
 
     @Override

--- a/src/main/java/com/conveyal/gtfs/loader/Table.java
+++ b/src/main/java/com/conveyal/gtfs/loader/Table.java
@@ -1025,7 +1025,7 @@ public class Table {
                 if (isOrderField) duplicateIdError.setSequence(value);
                 errors.add(duplicateIdError);
             }
-        } else if (field.name.equals(keyField)) {
+        } else if (field.name.equals(keyField) && !field.isForeignReference()) {
             // We arrive here if the field is not a foreign reference and not the unique key field on the table (e.g.,
             // shape_pt_sequence), but is still a key on the table. For example, this is where we add shape_id from
             // the shapes table, so that when we check the referential integrity of trips#shape_id, we know that the

--- a/src/main/java/com/conveyal/gtfs/loader/TimeField.java
+++ b/src/main/java/com/conveyal/gtfs/loader/TimeField.java
@@ -1,11 +1,14 @@
 package com.conveyal.gtfs.loader;
 
+import com.conveyal.gtfs.error.NewGTFSError;
 import com.conveyal.gtfs.error.NewGTFSErrorType;
 import com.conveyal.gtfs.storage.StorageException;
 
 import java.sql.JDBCType;
 import java.sql.PreparedStatement;
 import java.sql.SQLType;
+import java.util.Collections;
+import java.util.Set;
 
 /**
  * A field in the format HH:MM:SS, which will be stored as a number of seconds after midnight.
@@ -17,9 +20,11 @@ public class TimeField extends Field {
     }
 
     @Override
-    public void setParameter(PreparedStatement preparedStatement, int oneBasedIndex, String string) {
+    public Set<NewGTFSError> setParameter(PreparedStatement preparedStatement, int oneBasedIndex, String string) {
         try {
-            preparedStatement.setInt(oneBasedIndex, getSeconds(string));
+            ValidateFieldResult<Integer> result = getSeconds(string);
+            preparedStatement.setInt(oneBasedIndex, result.clean);
+            return result.errors;
         } catch (Exception ex) {
             throw new StorageException(ex);
         }
@@ -27,30 +32,34 @@ public class TimeField extends Field {
 
     // Actually this is converting the string. Can we use some JDBC existing functions for this?
     @Override
-    public String validateAndConvert(String hhmmss) {
-        return Integer.toString(getSeconds(hhmmss));
+    public ValidateFieldResult<String> validateAndConvert(String hhmmss) {
+        return ValidateFieldResult.from(getSeconds(hhmmss));
     }
 
-    private static int getSeconds (String hhmmss) {
+    private static ValidateFieldResult<Integer> getSeconds (String hhmmss) {
+        ValidateFieldResult<Integer> result = new ValidateFieldResult<>();
         // Accept hh:mm:ss or h:mm:ss for single-digit hours.
         if (hhmmss.length() != 8 && hhmmss.length() != 7) {
-            throw new StorageException(NewGTFSErrorType.TIME_FORMAT, hhmmss);
+            result.errors.add(NewGTFSError.forFeed(NewGTFSErrorType.TIME_FORMAT, hhmmss));
+            return result;
         }
         String[] fields = hhmmss.split(":");
         if (fields.length != 3) {
-            throw new StorageException(NewGTFSErrorType.TIME_FORMAT, hhmmss);
+            result.errors.add(NewGTFSError.forFeed(NewGTFSErrorType.TIME_FORMAT, hhmmss));
+            return result;
         }
         int h = Integer.parseInt(fields[0]);
         int m = Integer.parseInt(fields[1]);
         int s = Integer.parseInt(fields[2]);
         // Other than the Moscow-Pyongyang route at 8.5 days, most of the longest services are around 6 days.
-        if (h < 0) throw new StorageException(NewGTFSErrorType.NUMBER_NEGATIVE, hhmmss);
-        if (h > 150) throw new StorageException(NewGTFSErrorType.NUMBER_TOO_LARGE, hhmmss);
-        if (m < 0) throw new StorageException(NewGTFSErrorType.NUMBER_NEGATIVE, hhmmss);
-        if (m > 59) throw new StorageException(NewGTFSErrorType.NUMBER_TOO_LARGE, hhmmss);
-        if (s < 0) throw new StorageException(NewGTFSErrorType.NUMBER_NEGATIVE, hhmmss);
-        if (s > 59) throw new StorageException(NewGTFSErrorType.NUMBER_TOO_LARGE, hhmmss);
-        return ((h * 60) + m) * 60 + s;
+        if (h < 0) result.errors.add(NewGTFSError.forFeed(NewGTFSErrorType.NUMBER_NEGATIVE, hhmmss));
+        if (h > 150) result.errors.add(NewGTFSError.forFeed(NewGTFSErrorType.NUMBER_TOO_LARGE, hhmmss));
+        if (m < 0) result.errors.add(NewGTFSError.forFeed(NewGTFSErrorType.NUMBER_NEGATIVE, hhmmss));
+        if (m > 59) result.errors.add(NewGTFSError.forFeed(NewGTFSErrorType.NUMBER_TOO_LARGE, hhmmss));
+        if (s < 0) result.errors.add(NewGTFSError.forFeed(NewGTFSErrorType.NUMBER_NEGATIVE, hhmmss));
+        if (s > 59) result.errors.add(NewGTFSError.forFeed(NewGTFSErrorType.NUMBER_TOO_LARGE, hhmmss));
+        result.clean = ((h * 60) + m) * 60 + s;
+        return result;
     }
 
     @Override

--- a/src/main/java/com/conveyal/gtfs/loader/URLField.java
+++ b/src/main/java/com/conveyal/gtfs/loader/URLField.java
@@ -1,10 +1,14 @@
 package com.conveyal.gtfs.loader;
 
+import com.conveyal.gtfs.error.NewGTFSError;
+import com.conveyal.gtfs.error.NewGTFSErrorType;
 import com.conveyal.gtfs.storage.StorageException;
 
+import java.net.URL;
 import java.sql.JDBCType;
 import java.sql.PreparedStatement;
 import java.sql.SQLType;
+import java.util.Set;
 
 /**
  * Created by abyrd on 2017-03-31
@@ -16,19 +20,22 @@ public class URLField extends Field {
     }
 
     /** Check that a string can be properly parsed and is in range. */
-    public String validateAndConvert (String string) {
+    public ValidateFieldResult<String> validateAndConvert (String string) {
+        ValidateFieldResult<String> result = cleanString(string);
         try {
-            string = cleanString(string);
-            // new URL(cleanString); TODO call this to validate, but we can't default to zero
-            return string;
+            new URL(result.clean); // TODO call this to validate, but we can't default to zero
+            return result;
         } catch (Exception ex) {
-            throw new StorageException(ex);
+            result.errors.add(NewGTFSError.forFeed(NewGTFSErrorType.URL_FORMAT, string));
+            return result;
         }
     }
 
-    public void setParameter(PreparedStatement preparedStatement, int oneBasedIndex, String string) {
+    public Set<NewGTFSError> setParameter(PreparedStatement preparedStatement, int oneBasedIndex, String string) {
         try {
-            preparedStatement.setString(oneBasedIndex, validateAndConvert(string));
+            ValidateFieldResult<String> result = validateAndConvert(string);
+            preparedStatement.setString(oneBasedIndex, result.clean);
+            return result.errors;
         } catch (Exception ex) {
             throw new StorageException(ex);
         }

--- a/src/main/java/com/conveyal/gtfs/loader/ValidateFieldResult.java
+++ b/src/main/java/com/conveyal/gtfs/loader/ValidateFieldResult.java
@@ -1,0 +1,35 @@
+package com.conveyal.gtfs.loader;
+
+import com.conveyal.gtfs.error.NewGTFSError;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * This mini helper class is used during feed loading to return both:
+ * - a cleaned value of arbitrary type T and
+ * - any errors encountered while validating the original value.
+ *
+ * Previously we resorted to returning a single validated value and throwing exceptions if bad values were encountered,
+ * but this kept us from being able to do both things at once: repair the value AND collect errors on the offending input.
+ */
+public class ValidateFieldResult<T> {
+    public T clean;
+    public Set<NewGTFSError> errors = new HashSet<>();
+
+    public ValidateFieldResult() {}
+
+    /** Constructor used to set a default value (which may then be updated with the clean value). */
+    public ValidateFieldResult(T defaultValue) {
+        this.clean = defaultValue;
+    }
+
+    /** Builder method that constructs a ValidateFieldResult with type String from the input result. */
+    public static ValidateFieldResult<String> from(ValidateFieldResult result) {
+        ValidateFieldResult<String> stringResult = new ValidateFieldResult<>();
+        stringResult.clean = String.valueOf(result.clean);
+        stringResult.errors.addAll(result.errors);
+        return stringResult;
+    }
+
+}

--- a/src/test/java/com/conveyal/gtfs/GTFSTest.java
+++ b/src/test/java/com/conveyal/gtfs/GTFSTest.java
@@ -618,8 +618,8 @@ public class GTFSTest {
                 for (ValuePair valuePair : valuePairs) {
                     assertThat(
                         String.format("The value expected for %s was not found", field),
-                        valuePair.expected,
-                        equalTo(valuePair.found)
+                        valuePair.found,
+                        equalTo(valuePair.expected)
                     );
                 }
             }

--- a/src/test/resources/fake-agency-bad-calendar-date/calendar_dates.txt
+++ b/src/test/resources/fake-agency-bad-calendar-date/calendar_dates.txt
@@ -1,3 +1,7 @@
 service_id,date,exception_type
 04100312-8fe1-46a5-a9f2-556f39478f57,bad_date,2
 04100312-8fe1-46a5-a9f2-556f39478f57,bad_date2,1
+123_ID_NOT_EXISTS,20190301,2
+123_ID_NOT_EXISTS,20190301,1
+123_ID_NOT_EXISTS,bad_date,1
+123_ID_NOT_EXISTS,bad_date,2


### PR DESCRIPTION
This PR fixes #191 by modifying how values encountered during GTFS loads are validated and cleaned. It uses a helper return class `ValidateFieldResult` to store both the cleaned value and any errors found during validation, which then are bubbled up and handled in `JdbcGtfsLoader`.

It also adds a new error type `ILLEGAL_FIELD_VALUE` to resolve the primary issue of not tracking instances where bad character sequences where found in a GTFS feed.

This also fixes #202.