### PR TITLE
Allow nested queries where field names don't  match

### DIFF
--- a/src/main/java/com/conveyal/gtfs/graphql/GraphQLGtfsSchema.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/GraphQLGtfsSchema.java
@@ -333,6 +333,18 @@ public class GraphQLGtfsSchema {
             .field(MapFetcher.field("parent_station"))
             .field(MapFetcher.field("location_type", GraphQLInt))
             .field(MapFetcher.field("wheelchair_boarding", GraphQLInt))
+            // Returns all stops that reference parent stop's stop_id
+            .field(newFieldDefinition()
+                    .name("child_stops")
+                    .type(new GraphQLList(new GraphQLTypeReference("stop")))
+                    .dataFetcher(new JDBCFetcher(
+                        "stops",
+                        "stop_id",
+                        null,
+                        false,
+                        "parent_station"
+                    ))
+                    .build())
             .field(RowCountFetcher.field("stop_time_count", "stop_times", "stop_id"))
             .field(newFieldDefinition()
                     .name("patterns")

--- a/src/test/java/com/conveyal/gtfs/GTFSFeedTest.java
+++ b/src/test/java/com/conveyal/gtfs/GTFSFeedTest.java
@@ -252,7 +252,8 @@ public class GTFSFeedTest {
         GTFSFeed feed = GTFSFeed.fromFile(simpleGtfsZipFileName);
         assertThat(
             feed.getSpatialIndex().size(),
-            equalTo(2)
+            // This should reflect the number of stops in src/test/resources/fake-agency/stops.txt
+            equalTo(4)
         );
     }
 

--- a/src/test/java/com/conveyal/gtfs/graphql/GTFSGraphQLTest.java
+++ b/src/test/java/com/conveyal/gtfs/graphql/GTFSGraphQLTest.java
@@ -191,7 +191,8 @@ public class GTFSGraphQLTest {
         assertThat(queryGraphQL("superNested.txt"), matchesSnapshot());
     }
 
-    /** Tests whether a graphQL query that has superflous and redundant nesting can find the right result.
+    /**
+     * Tests whether a graphQL query that has superflous and redundant nesting can find the right result.
      * If the graphQL dataloader is enabled correctly, there will not be any repeating sql queries in the logs.
      * Furthermore, some queries should have been combined together.
      */

--- a/src/test/java/com/conveyal/gtfs/graphql/GTFSGraphQLTest.java
+++ b/src/test/java/com/conveyal/gtfs/graphql/GTFSGraphQLTest.java
@@ -2,7 +2,6 @@ package com.conveyal.gtfs.graphql;
 
 import com.conveyal.gtfs.TestUtils;
 import com.conveyal.gtfs.loader.FeedLoadResult;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import graphql.GraphQL;
 import org.apache.commons.io.IOUtils;
 import org.junit.AfterClass;
@@ -40,10 +39,8 @@ public class GTFSGraphQLTest {
     private static DataSource testInjectionDataSource;
     private static String testInjectionNamespace;
 
-    private ObjectMapper mapper = new ObjectMapper();
-
     @BeforeClass
-    public static void setUpClass() throws SQLException, IOException {
+    public static void setUpClass() throws IOException {
         // create a new database
         testDBName = TestUtils.generateNewDB();
         String dbConnectionUrl = String.format("jdbc:postgresql://localhost/%s", testDBName);
@@ -74,74 +71,80 @@ public class GTFSGraphQLTest {
         TestUtils.dropDB(testInjectionDBName);
     }
 
-    // tests that the graphQL schema can initialize
+    /** Tests that the graphQL schema can initialize. */
     @Test(timeout=5000)
     public void canInitialize() {
         GTFSGraphQL.initialize(testDataSource);
         GraphQL graphQL = GTFSGraphQL.getGraphQl();
     }
 
-    // tests that the root element of a feed can be fetched
+    /** Tests that the root element of a feed can be fetched. */
     @Test(timeout=5000)
     public void canFetchFeed() throws IOException {
         assertThat(queryGraphQL("feed.txt"), matchesSnapshot());
     }
 
-    // tests that the row counts of a feed can be fetched
+    /** Tests that the row counts of a feed can be fetched. */
     @Test(timeout=5000)
     public void canFetchFeedRowCounts() throws IOException {
         assertThat(queryGraphQL("feedRowCounts.txt"), matchesSnapshot());
     }
 
-    // tests that the errors of a feed can be fetched
+    /** Tests that the errors of a feed can be fetched. */
     @Test(timeout=5000)
     public void canFetchErrors() throws IOException {
         assertThat(queryGraphQL("feedErrors.txt"), matchesSnapshot());
     }
 
-    // tests that the feed_info of a feed can be fetched
+    /** Tests that the feed_info of a feed can be fetched. */
     @Test(timeout=5000)
     public void canFetchFeedInfo() throws IOException {
         assertThat(queryGraphQL("feedFeedInfo.txt"), matchesSnapshot());
     }
 
-    // tests that the patterns of a feed can be fetched
+    /** Tests that the patterns of a feed can be fetched. */
     @Test(timeout=5000)
     public void canFetchPatterns() throws IOException {
         assertThat(queryGraphQL("feedPatterns.txt"), matchesSnapshot());
     }
 
-    // tests that the agencies of a feed can be fetched
+    /** Tests that the agencies of a feed can be fetched. */
     @Test(timeout=5000)
     public void canFetchAgencies() throws IOException {
         assertThat(queryGraphQL("feedAgencies.txt"), matchesSnapshot());
     }
 
-    // tests that the calendars of a feed can be fetched
+    /** Tests that the calendars of a feed can be fetched. */
     @Test(timeout=5000)
     public void canFetchCalendars() throws IOException {
         assertThat(queryGraphQL("feedCalendars.txt"), matchesSnapshot());
     }
 
-    // tests that the fares of a feed can be fetched
+    /** Tests that the fares of a feed can be fetched. */
     @Test(timeout=5000)
     public void canFetchFares() throws IOException {
         assertThat(queryGraphQL("feedFares.txt"), matchesSnapshot());
     }
 
-    // tests that the routes of a feed can be fetched
+    /** Tests that the routes of a feed can be fetched. */
     @Test(timeout=5000)
     public void canFetchRoutes() throws IOException {
         assertThat(queryGraphQL("feedRoutes.txt"), matchesSnapshot());
     }
 
-    // tests that the stops of a feed can be fetched
+    /** Tests that the stops of a feed can be fetched. */
     @Test(timeout=5000)
     public void canFetchStops() throws IOException {
         assertThat(queryGraphQL("feedStops.txt"), matchesSnapshot());
     }
 
-    // tests that the trips of a feed can be fetched
+    /** Tests that the stops of a feed can be fetched. */
+    @Test(timeout=5000)
+    public void canFetchStopWithChildren() throws IOException {
+        assertThat(queryGraphQL("feedStopWithChildren.txt"), matchesSnapshot());
+    }
+
+    /** Tests that the trips of a feed can be fetched. */
     @Test(timeout=5000)
     public void canFetchTrips() throws IOException {
         assertThat(queryGraphQL("feedTrips.txt"), matchesSnapshot());
@@ -149,19 +152,19 @@ public class GTFSGraphQLTest {
 
     // TODO: make tests for schedule_exceptions / calendar_dates
 
-    // tests that the stop times of a feed can be fetched
+    /** Tests that the stop times of a feed can be fetched. */
     @Test(timeout=5000)
     public void canFetchStopTimes() throws IOException {
         assertThat(queryGraphQL("feedStopTimes.txt"), matchesSnapshot());
     }
 
-    // tests that the stop times of a feed can be fetched
+    /** Tests that the stop times of a feed can be fetched. */
     @Test(timeout=5000)
     public void canFetchServices() throws IOException {
         assertThat(queryGraphQL("feedServices.txt"), matchesSnapshot());
     }
 
-    // tests that the stop times of a feed can be fetched
+    /** Tests that the stop times of a feed can be fetched. */
     @Test(timeout=5000)
     public void canFetchRoutesAndFilterTripsByDateAndTime() throws IOException {
         Map<String, Object> variables = new HashMap<String, Object>();
@@ -175,29 +178,31 @@ public class GTFSGraphQLTest {
         );
     }
 
-    // tests that the limit argument applies properly to a fetcher defined with autolimit set to false
+    /** Tests that the limit argument applies properly to a fetcher defined with autolimit set to false. */
     @Test(timeout=5000)
     public void canFetchNestedEntityWithLimit() throws IOException {
         assertThat(queryGraphQL("feedStopsStopTimeLimit.txt"), matchesSnapshot());
     }
 
-    // tests whether a graphQL query that has superflous and redundant nesting can find the right result
+    /** Tests whether a graphQL query that has superflous and redundant nesting can find the right result. */
     // if the graphQL dataloader is enabled correctly, there will not be any repeating sql queries in the logs
     @Test(timeout=5000)
     public void canFetchMultiNestedEntities() throws IOException {
         assertThat(queryGraphQL("superNested.txt"), matchesSnapshot());
     }
-    // tests whether a graphQL query that has superflous and redundant nesting can find the right result
-    // if the graphQL dataloader is enabled correctly, there will not be any repeating sql queries in the logs
-    // furthermore, some queries should have been combined together
+
+    /** Tests whether a graphQL query that has superflous and redundant nesting can find the right result.
+     * If the graphQL dataloader is enabled correctly, there will not be any repeating sql queries in the logs.
+     * Furthermore, some queries should have been combined together.
+     */
     @Test(timeout=5000)
     public void canFetchMultiNestedEntitiesWithoutLimits() throws IOException {
         assertThat(queryGraphQL("superNestedNoLimits.txt"), matchesSnapshot());
     }
 
     /**
-     * attempt to fetch more than one record with SQL injection as inputs
-     * the graphql library should properly escape the string and return 0 results for stops
+     * Attempt to fetch more than one record with SQL injection as inputs.
+     * The graphql library should properly escape the string and return 0 results for stops.
      */
     @Test(timeout=5000)
     public void canSanitizeSQLInjectionSentAsInput() throws IOException {
@@ -215,8 +220,8 @@ public class GTFSGraphQLTest {
     }
 
     /**
-     * attempt run a graphql query when one of the pieces of data contains a SQL injection
-     * the graphql library should properly escape the string and complete the queries
+     * Attempt to run a graphql query when one of the pieces of data contains a SQL injection.
+     * The graphql library should properly escape the string and complete the queries.
      */
     @Test(timeout=5000)
     public void canSanitizeSQLInjectionSentAsKeyValue() throws IOException, SQLException {
@@ -238,7 +243,7 @@ public class GTFSGraphQLTest {
 
 
     /**
-     * Helper method to make a query with default variables
+     * Helper method to make a query with default variables.
      *
      * @param queryFilename the filename that should be used to generate the GraphQL query.  This file must be present
      *                      in the `src/test/resources/graphql` folder
@@ -250,7 +255,7 @@ public class GTFSGraphQLTest {
     }
 
     /**
-     * Helper method to execute a GraphQL query and return the result
+     * Helper method to execute a GraphQL query and return the result.
      *
      * @param queryFilename the filename that should be used to generate the GraphQL query.  This file must be present
      *                      in the `src/test/resources/graphql` folder

--- a/src/test/resources/fake-agency/stops.txt
+++ b/src/test/resources/fake-agency/stops.txt
@@ -1,3 +1,5 @@
 stop_id,stop_code,stop_name,stop_desc,stop_lat,stop_lon,zone_id,stop_url,location_type,parent_station,stop_timezone,wheelchair_boarding
 4u6g,,Butler Ln,,37.0612132,-122.0074332,,,0,,,
 johv,,Scotts Valley Dr & Victor Sq,,37.0590172,-122.0096058,,,0,,,
+123,,Parent Station,,37.0666,-122.0777,,,1,,,
+1234,,Child Stop,,37.06662,-122.07772,,,0,123,,

--- a/src/test/resources/graphql/feedStopWithChildren.txt
+++ b/src/test/resources/graphql/feedStopWithChildren.txt
@@ -1,0 +1,13 @@
+query ($namespace: String, $stop_id: [String]) {
+  feed(namespace: $namespace) {
+    feed_version
+    stops(stop_id: $stop_id) {
+      stop_id
+      stop_name
+      child_stops {
+        stop_id
+        stop_name
+      }
+    }
+  }
+}

--- a/src/test/resources/snapshots/com/conveyal/gtfs/graphql/GTFSGraphQLTest/canFetchErrors.json
+++ b/src/test/resources/snapshots/com/conveyal/gtfs/graphql/GTFSGraphQLTest/canFetchErrors.json
@@ -26,11 +26,27 @@
         "error_type" : "FEED_TRAVEL_TIMES_ROUNDED",
         "line_number" : null
       }, {
+        "bad_value" : "123",
+        "entity_id" : "123",
+        "entity_sequence" : null,
+        "entity_type" : "Stop",
+        "error_id" : 3,
+        "error_type" : "STOP_UNUSED",
+        "line_number" : 4
+      }, {
+        "bad_value" : "1234",
+        "entity_id" : "1234",
+        "entity_sequence" : null,
+        "entity_type" : "Stop",
+        "error_id" : 4,
+        "error_type" : "STOP_UNUSED",
+        "line_number" : 5
+      }, {
         "bad_value" : "20170916",
         "entity_id" : null,
         "entity_sequence" : null,
         "entity_type" : null,
-        "error_id" : 3,
+        "error_id" : 5,
         "error_type" : "DATE_NO_SERVICE",
         "line_number" : null
       } ],

--- a/src/test/resources/snapshots/com/conveyal/gtfs/graphql/GTFSGraphQLTest/canFetchFeedRowCounts.json
+++ b/src/test/resources/snapshots/com/conveyal/gtfs/graphql/GTFSGraphQLTest/canFetchFeedRowCounts.json
@@ -6,10 +6,10 @@
         "agency" : 1,
         "calendar" : 1,
         "calendar_dates" : 1,
-        "errors" : 4,
+        "errors" : 6,
         "routes" : 1,
         "stop_times" : 4,
-        "stops" : 2,
+        "stops" : 4,
         "trips" : 2
       },
       "snapshot_of" : null

--- a/src/test/resources/snapshots/com/conveyal/gtfs/graphql/GTFSGraphQLTest/canFetchNestedEntityWithLimit.json
+++ b/src/test/resources/snapshots/com/conveyal/gtfs/graphql/GTFSGraphQLTest/canFetchNestedEntityWithLimit.json
@@ -16,6 +16,12 @@
           "stop_sequence" : 2,
           "trip_id" : "a30277f8-e50a-4a85-9141-b1e0da9d429d"
         } ]
+      }, {
+        "stop_id" : "123",
+        "stop_times" : [ ]
+      }, {
+        "stop_id" : "1234",
+        "stop_times" : [ ]
       } ]
     }
   }

--- a/src/test/resources/snapshots/com/conveyal/gtfs/graphql/GTFSGraphQLTest/canFetchStopWithChildren.json
+++ b/src/test/resources/snapshots/com/conveyal/gtfs/graphql/GTFSGraphQLTest/canFetchStopWithChildren.json
@@ -1,0 +1,27 @@
+{
+  "data" : {
+    "feed" : {
+      "feed_version" : "1.0",
+      "stops" : [ {
+        "child_stops" : [ ],
+        "stop_id" : "4u6g",
+        "stop_name" : "Butler Ln"
+      }, {
+        "child_stops" : [ ],
+        "stop_id" : "johv",
+        "stop_name" : "Scotts Valley Dr & Victor Sq"
+      }, {
+        "child_stops" : [ {
+          "stop_id" : "1234",
+          "stop_name" : "Child Stop"
+        } ],
+        "stop_id" : "123",
+        "stop_name" : "Parent Station"
+      }, {
+        "child_stops" : [ ],
+        "stop_id" : "1234",
+        "stop_name" : "Child Stop"
+      } ]
+    }
+  }
+}

--- a/src/test/resources/snapshots/com/conveyal/gtfs/graphql/GTFSGraphQLTest/canFetchStops.json
+++ b/src/test/resources/snapshots/com/conveyal/gtfs/graphql/GTFSGraphQLTest/canFetchStops.json
@@ -62,6 +62,42 @@
         "stop_url" : null,
         "wheelchair_boarding" : null,
         "zone_id" : null
+      }, {
+        "id" : 4,
+        "location_type" : 1,
+        "parent_station" : null,
+        "patterns" : [ ],
+        "routes" : [ ],
+        "stop_code" : null,
+        "stop_desc" : null,
+        "stop_id" : "123",
+        "stop_lat" : 37.0666,
+        "stop_lon" : -122.0777,
+        "stop_name" : "Parent Station",
+        "stop_time_count" : 0,
+        "stop_times" : [ ],
+        "stop_timezone" : null,
+        "stop_url" : null,
+        "wheelchair_boarding" : null,
+        "zone_id" : null
+      }, {
+        "id" : 5,
+        "location_type" : 0,
+        "parent_station" : "123",
+        "patterns" : [ ],
+        "routes" : [ ],
+        "stop_code" : null,
+        "stop_desc" : null,
+        "stop_id" : "1234",
+        "stop_lat" : 37.06662,
+        "stop_lon" : -122.07772,
+        "stop_name" : "Child Stop",
+        "stop_time_count" : 0,
+        "stop_times" : [ ],
+        "stop_timezone" : null,
+        "stop_url" : null,
+        "wheelchair_boarding" : null,
+        "zone_id" : null
       } ]
     }
   }


### PR DESCRIPTION
The GraphQL nested queries up until this change relied on parent tables with foreign refs sharing
the same field name as the primary key on the child table. For example, trips could be joined to a
route on the shared field route_id. This change permits nesting children stops under a parent stop
using stops#parent_station, which will be joined on the parent join value found in stops#stop_id.

refs conveyal/datatools-ui#428