### PR TITLE
Fix schedule exceptions bug in DateListField

### DIFF
--- a/src/main/java/com/conveyal/gtfs/loader/DateListField.java
+++ b/src/main/java/com/conveyal/gtfs/loader/DateListField.java
@@ -34,7 +34,8 @@ public class DateListField extends Field {
     public Set<NewGTFSError> setParameter(PreparedStatement preparedStatement, int oneBasedIndex, String string) {
         try {
             String[] dateStrings = Arrays.stream(string.split(","))
-                    .map(DateField::validate)
+                    // Validate date strings and get the clean value.
+                    .map(s -> DateField.validate(s).clean)
                     .toArray(String[]::new);
             Array array = preparedStatement.getConnection().createArrayOf("text", dateStrings);
             preparedStatement.setArray(oneBasedIndex, array);

--- a/src/test/java/com/conveyal/gtfs/dto/ScheduleExceptionDTO.java
+++ b/src/test/java/com/conveyal/gtfs/dto/ScheduleExceptionDTO.java
@@ -1,0 +1,14 @@
+package com.conveyal.gtfs.dto;
+
+public class ScheduleExceptionDTO {
+    public String[] added_service;
+    public String[] custom_schedule;
+    public String[] dates;
+    public Integer exemplar;
+    public Integer id;
+    public String name;
+    public String[] removed_service;
+
+    /** Empty constructor for deserialization */
+    public ScheduleExceptionDTO() {}
+}

--- a/src/test/java/com/conveyal/gtfs/loader/JDBCTableWriterTest.java
+++ b/src/test/java/com/conveyal/gtfs/loader/JDBCTableWriterTest.java
@@ -326,8 +326,7 @@ public class JDBCTableWriterTest {
         // Store Table and Class values for use in test.
         final Table scheduleExceptionTable = Table.SCHEDULE_EXCEPTIONS;
         final Class<ScheduleExceptionDTO> scheduleExceptionDTOClass = ScheduleExceptionDTO.class;
-
-        // create new object to be saved
+        // Create new object to be saved.
         ScheduleExceptionDTO exceptionInput = new ScheduleExceptionDTO();
         exceptionInput.name = "Halloween";
         exceptionInput.exemplar = 9; // Add, swap, or remove type
@@ -338,21 +337,18 @@ public class JDBCTableWriterTest {
         String scheduleExceptionOutput = createTableWriter.create(mapper.writeValueAsString(exceptionInput), true);
         ScheduleExceptionDTO scheduleException = mapper.readValue(scheduleExceptionOutput,
                                                                          scheduleExceptionDTOClass);
-
-        // make sure saved data matches expected data
+        // Make sure saved data matches expected data.
         assertThat(scheduleException.removed_service[0], equalTo(simpleServiceId));
         ResultSet resultSet = getResultSetForId(scheduleException.id, scheduleExceptionTable, "removed_service");
         while (resultSet.next()) {
             String[] array = (String[]) resultSet.getArray(1).getArray();
             for (int i = 0; i < array.length; i++) {
                 assertEquals(exceptionInput.removed_service[i], array[i]);
-
             }
         }
         // try to update record
         String[] updatedDates = new String[]{"20191031", "20201031"};
         scheduleException.dates = updatedDates;
-
         // covert object to json and save it
         JdbcTableWriter updateTableWriter = createTestTableWriter(scheduleExceptionTable);
         String updateOutput = updateTableWriter.update(
@@ -362,17 +358,14 @@ public class JDBCTableWriterTest {
         );
         LOG.info("update {} output:", scheduleExceptionTable.name);
         LOG.info(updateOutput);
-
         ScheduleExceptionDTO updatedDTO = mapper.readValue(updateOutput, scheduleExceptionDTOClass);
-
-        // make sure saved data matches expected data
+        // Make sure saved data matches expected data.
         assertThat(updatedDTO.dates, equalTo(updatedDates));
         ResultSet rs2 = getResultSetForId(scheduleException.id, scheduleExceptionTable, "dates");
         while (rs2.next()) {
             String[] array = (String[]) rs2.getArray(1).getArray();
             for (int i = 0; i < array.length; i++) {
                 assertEquals(updatedDates[i], array[i]);
-
             }
         }
         // try to delete record
@@ -382,8 +375,7 @@ public class JDBCTableWriterTest {
             true
         );
         LOG.info("deleted {} records from {}", deleteOutput, scheduleExceptionTable.name);
-
-        // make sure route record does not exist in DB
+        // Make sure route record does not exist in DB.
         assertThatSqlQueryYieldsZeroRows(getAllColumnsForId(scheduleException.id, scheduleExceptionTable));
     }
 

--- a/src/test/java/com/conveyal/gtfs/loader/JDBCTableWriterTest.java
+++ b/src/test/java/com/conveyal/gtfs/loader/JDBCTableWriterTest.java
@@ -264,7 +264,7 @@ public class JDBCTableWriterTest {
         LOG.info("deleted {} records from {}", deleteOutput, fareTable.name);
 
         // make sure fare_attributes record does not exist in DB
-        assertThatSqlQueryYieldsZeroRows(getAllColumnsForId(createdFare.id, fareTable);
+        assertThatSqlQueryYieldsZeroRows(getAllColumnsForId(createdFare.id, fareTable));
 
         // make sure fare_rules record does not exist in DB
         assertThatSqlQueryYieldsZeroRows(getAllColumnsForId(createdFare.fare_rules[0].id, Table.FARE_RULES));


### PR DESCRIPTION
fixes #214

### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

A change to the return value for `Field#validate` (from String to ValidateFieldResult) caused an issue for creating/updating schedule exceptions with values for the `dates` field. This fixes the validate function and adds a CRUD test for schedule exceptions.