### PR TITLE
Omit where clauses containing columns missing from table

### DIFF
--- a/src/main/java/com/conveyal/gtfs/graphql/GraphQLGtfsSchema.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/GraphQLGtfsSchema.java
@@ -190,11 +190,13 @@ public class GraphQLGtfsSchema {
             .field(MapFetcher.field("pattern_id"))
             .field(newFieldDefinition()
                     .name("stop_times")
-                    // forward reference to the as yet undefined stopTimeType (must be defined after tripType)
+                    // forward reference to the as yet undefined stopTimeType (must be defined
+                    // after tripType)
                     .type(new GraphQLList(new GraphQLTypeReference("stopTime")))
-                    // FIXME Update JDBCFetcher to have noLimit boolean for fetchers on "naturally" nested types
-                    // (i.e., nested types that typically would only be nested under another entity and only make sense
-                    // with the entire set -- fares -> fare rules, trips -> stop times, patterns -> pattern stops/shapes)
+                    // FIXME Update JDBCFetcher to have noLimit boolean for fetchers on "naturally"
+                    //  nested types (i.e., nested types that typically would only be nested under
+                    //  another entity and only make sense with the entire set -- fares -> fare
+                    //  rules, trips -> stop times, patterns -> pattern stops/shapes)
                     .argument(intArg(LIMIT_ARG))
                     .dataFetcher(new JDBCFetcher(
                             "stop_times",

--- a/src/main/java/com/conveyal/gtfs/graphql/fetchers/JDBCFetcher.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/fetchers/JDBCFetcher.java
@@ -225,7 +225,12 @@ public class JDBCFetcher implements DataFetcher<List<Map<String, Object>>> {
                 // to occur (e.g., if we're joining trips to a route based on their route_id), but
                 // there are cases (joining child stops to a parent stop based on the parent_station
                 // field) where this would result in errors.
-                LOG.warn("{} does not exist in {}.{} table", childJoinField, namespace, tableName);
+                LOG.warn(
+                    "{} does not exist in {}.{} table. Cannot create where clause for join.",
+                    childJoinField,
+                    namespace,
+                    tableName
+                );
                 return results;
             }
         }

--- a/src/test/resources/fake-agency-bad-calendar-date/stops.txt
+++ b/src/test/resources/fake-agency-bad-calendar-date/stops.txt
@@ -1,3 +1,3 @@
-stop_id,stop_code,stop_name,stop_desc,stop_lat,stop_lon,zone_id,stop_url,location_type,parent_station,stop_timezone,wheelchair_boarding
-4u6g,,Butler Ln,,37.0612132,-122.0074332,,,0,,,
-johv,,Scotts Valley Dr & Victor Sq,,37.0590172,-122.0096058,,,0,,,
+stop_id,stop_code,stop_name,stop_desc,stop_lat,stop_lon,zone_id,stop_url,location_type,stop_timezone,wheelchair_boarding
+4u6g,,Butler Ln,,37.0612132,-122.0074332,,,0,,
+johv,,Scotts Valley Dr & Victor Sq,,37.0590172,-122.0096058,,,0,,

--- a/src/test/resources/snapshots/com/conveyal/gtfs/graphql/GTFSGraphQLTest/canFetchStopsWithoutParentStationColumn.json
+++ b/src/test/resources/snapshots/com/conveyal/gtfs/graphql/GTFSGraphQLTest/canFetchStopsWithoutParentStationColumn.json
@@ -1,0 +1,16 @@
+{
+  "data" : {
+    "feed" : {
+      "feed_version" : "1.0",
+      "stops" : [ {
+        "child_stops" : [ ],
+        "stop_id" : "4u6g",
+        "stop_name" : "Butler Ln"
+      }, {
+        "child_stops" : [ ],
+        "stop_id" : "johv",
+        "stop_name" : "Scotts Valley Dr & Victor Sq"
+      } ]
+    }
+  }
+}


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This fixes #217 by adapting a pre-existing method to check for the existence of columns in a table before adding a where clause that contains a missing column.