### PR TITLE
ci(semantic-release): pin semantic-release to v15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install: |
 
 # Install semantic-release
 before_script:
-  - yarn global add @conveyal/maven-semantic-release semantic-release
+  - yarn global add @conveyal/maven-semantic-release semantic-release@15
 
 # Replace Travis's default build step.
 # Run all Maven phases at once up through verify, install, and deploy.


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Semantic-release v16 is going to have a breaking change that will make maven-semantic-release not work properly (see https://github.com/conveyal/maven-semantic-release/issues/10). Therefore this change preemptively fixes semantic-release to v15.x.x to prevent future breakage until maven-semantic-release can be updated to support semantic-release v16.