### PR TITLE
Do not log error for unescaped backslashes

### DIFF
--- a/src/main/java/com/conveyal/gtfs/loader/Field.java
+++ b/src/main/java/com/conveyal/gtfs/loader/Field.java
@@ -91,7 +91,6 @@ public abstract class Field {
         return String.join(" ", name, getSqlTypeName());
     }
 
-    // TODO test for input with tabs, newlines, carriage returns, and slashes in it.
     protected static ValidateFieldResult<String> cleanString (String string) {
         return cleanString(new ValidateFieldResult<>(string));
     }
@@ -106,7 +105,12 @@ public abstract class Field {
                 result.clean = result.clean.replace(illegalChar.illegalSequence, illegalChar.replacement);
                 // We don't know the Table or line number here, but when the errors bubble up, these values should be
                 // assigned to the errors.
-                result.errors.add(NewGTFSError.forFeed(NewGTFSErrorType.ILLEGAL_FIELD_VALUE, illegalChar.description));
+                if (!illegalChar.illegalSequence.equals("\\")) {
+                    // Do not include error entry for unescaped backslash. While this character
+                    // sequence is problematic for Postgres, it is not technically an illegal
+                    // value according to the GTFS specification.
+                    result.errors.add(NewGTFSError.forFeed(NewGTFSErrorType.ILLEGAL_FIELD_VALUE, illegalChar.description));
+                }
             }
         }
         return result;


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR fixes #228. If the illegal sequence encountered if an unescaped backslash, it will not record an ILLEGAL_FIELD_VALUE error, but otherwise behave the same (return a cleaned string for storage in the db).