### PR TITLE
Properly track primary keys in proprietary files

### DIFF
--- a/src/main/java/com/conveyal/gtfs/loader/ReferenceTracker.java
+++ b/src/main/java/com/conveyal/gtfs/loader/ReferenceTracker.java
@@ -106,7 +106,14 @@ public class ReferenceTracker {
                 listOfUniqueIds = this.transitIdsWithSequence;
                 uniqueId = String.join(":", field.name, keyValue, value);
             }
-            // Add ID and check duplicate reference in entity-scoped IDs (e.g., stop_id:12345)
+            if (table.required.equals(Requirement.PROPRIETARY)) {
+                // Some proprietary tables in the GTFS+ spec do not conform to the general principle in GTFS where a key
+                // field (e.g., stop_id) only acts as the primary key field in the entity's table. For example, stop_id
+                // acts as a primary key on stop_attributes.txt, so we prepend the table name to the unique ID for these
+                // tables when checking for duplicate entries.
+                uniqueId = String.join(":", table.name, field.name, value);
+            }
+             // Add ID and check duplicate reference in entity-scoped IDs (e.g., stop_id:12345)
             boolean valueAlreadyExists = !listOfUniqueIds.add(uniqueId);
             if (valueAlreadyExists) {
                 // If the value is a duplicate, add an error.


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Some proprietary tables in the GTFS+ spec do not conform to the general principle in GTFS where a key field (e.g., stop_id) only acts as the primary key field in the entity's table. For example,
stop_id acts as a primary key on stop_attributes.txt, so we prepend the table name to the unique ID
for these tables when checking for duplicate entries.