### PR TITLE
fix(ReferenceTracker): add table name to full id

### DIFF
--- a/src/main/java/com/conveyal/gtfs/loader/ReferenceTracker.java
+++ b/src/main/java/com/conveyal/gtfs/loader/ReferenceTracker.java
@@ -111,7 +111,7 @@ public class ReferenceTracker {
                 // field (e.g., stop_id) only acts as the primary key field in the entity's table. For example, stop_id
                 // acts as a primary key on stop_attributes.txt, so we prepend the table name to the unique ID for these
                 // tables when checking for duplicate entries.
-                uniqueId = String.join(":", table.name, field.name, value);
+                uniqueId = String.join(":", table.name, uniqueId);
             }
              // Add ID and check duplicate reference in entity-scoped IDs (e.g., stop_id:12345)
             boolean valueAlreadyExists = !listOfUniqueIds.add(uniqueId);


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR contains a fixes #251 by qualifying the previously defined unique ID with the table name, rather than just containing the ordinal value.