### PR TITLE
Remove Conveyal geojson module to fix Travis build/dep issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,8 +207,10 @@
   <repositories>
     <repository>
       <id>osgeo</id>
-      <name>Open Source Geospatial Foundation Repository</name>
-      <url>https://download.osgeo.org/webdav/geotools/</url>
+      <name>OSGeo Release Repository</name>
+      <url>https://repo.osgeo.org/repository/release/</url>
+      <snapshots><enabled>false</enabled></snapshots>
+      <releases><enabled>true</enabled></releases>
     </repository>
     <!--  used for importing java projects from github -->
     <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -206,11 +206,6 @@
 
   <repositories>
     <repository>
-      <id>conveyal</id>
-      <name>Conveyal Maven Repository</name>
-       <url>https://maven.conveyal.com/</url>
-    </repository>
-    <repository>
       <id>osgeo</id>
       <name>Open Source Geospatial Foundation Repository</name>
       <url>https://download.osgeo.org/webdav/geotools/</url>
@@ -330,12 +325,6 @@
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
       <version>1.4</version>
-    </dependency>
-    <!-- We should really find a way to do this without forking Jackson -->
-    <dependency>
-      <groupId>com.conveyal</groupId>
-      <artifactId>jackson2-geojson</artifactId>
-      <version>0.8</version>
     </dependency>
     <!-- JDBC support for Postgres databases. More modules would need to be added to access H2, SQLite etc. -->
     <dependency>

--- a/src/main/java/com/conveyal/gtfs/GTFSMain.java
+++ b/src/main/java/com/conveyal/gtfs/GTFSMain.java
@@ -39,6 +39,7 @@ public class GTFSMain {
 
         if(cmd.hasOption("validate")) {
             feed.validate();
+            // FIXME: See JsonManager.class for discussion about potential issues serializing GeoJSON.
             JsonManager<ValidationResult> json = new JsonManager(ValidationResult.class);
             ValidationResult result = new ValidationResult(arguments[0], feed);
             String resultString = json.writePretty(result);

--- a/src/main/java/com/conveyal/gtfs/util/json/JsonManager.java
+++ b/src/main/java/com/conveyal/gtfs/util/json/JsonManager.java
@@ -1,6 +1,5 @@
 package com.conveyal.gtfs.util.json;
 
-import com.conveyal.geojson.GeoJsonModule;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -36,7 +35,11 @@ public class JsonManager<T> {
         this.theClass = theClass;
         this.mapper = new ObjectMapper();
         mapper.addMixInAnnotations(Rectangle2D.class, Rectangle2DMixIn.class);
-        mapper.registerModule(new GeoJsonModule());
+        // FIXME: This codepath is deprecated in versions greater than 4.x, but there may be a need to replace this
+        //  Jackson module to handle GeoJSON. If there is an issue with de-/serialization, might be good to take a look
+        //  at https://github.com/opentripplanner/OpenTripPlanner/blob/08e034faace255e092211290220af3f60e553fa7/pom.xml#L515-L532
+        //  (dependency used in OTP).
+//        mapper.registerModule(new GeoJsonModule());
         SimpleModule deser = new SimpleModule();
 
         deser.addDeserializer(LocalDate.class, new JacksonSerializers.LocalDateStringDeserializer());


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

The Conveyal maven repo appears to no longer exist, so the GeoJSON Jackson module is no longer
available.