### PR TITLE
Add normalizeStopTimes flag to RDBMS snapshots preserve stop_sequence vals

### DIFF
--- a/src/main/java/com/conveyal/gtfs/GTFS.java
+++ b/src/main/java/com/conveyal/gtfs/GTFS.java
@@ -81,14 +81,22 @@ public abstract class GTFS {
      *   1. The tables' id column has been modified to be auto-incrementing.
      *   2. Primary keys may be added to certain columns/tables.
      *   3. Additional editor-specific columns are added to certain tables.
-     * @param feedId        feed ID (schema namespace) to copy from
-     * @param dataSource    JDBC connection to existing database
-     * @return              FIXME should this be a separate SnapshotResult object?
+     * @param feedId                feed ID (schema namespace) to copy from
+     * @param dataSource            JDBC connection to existing database
+     * @param normalizeStopTimes    whether to normalize stop sequence values on snapshot
+     * @return the result of the snapshot
      */
-    public static SnapshotResult makeSnapshot (String feedId, DataSource dataSource) {
-        JdbcGtfsSnapshotter snapshotter = new JdbcGtfsSnapshotter(feedId, dataSource);
+    public static SnapshotResult makeSnapshot (String feedId, DataSource dataSource, boolean normalizeStopTimes) {
+        JdbcGtfsSnapshotter snapshotter = new JdbcGtfsSnapshotter(feedId, dataSource, normalizeStopTimes);
         SnapshotResult result = snapshotter.copyTables();
         return result;
+    }
+
+    /**
+     * Overloaded makeSnapshot method that defaults to normalize stop times.
+     */
+    public static SnapshotResult makeSnapshot (String feedId, DataSource dataSource) {
+        return makeSnapshot(feedId, dataSource, true);
     }
 
     /**
@@ -277,7 +285,7 @@ public abstract class GTFS {
             }
             if (namespaceToSnapshot != null) {
                 LOG.info("Snapshotting feed with unique identifier {}", namespaceToSnapshot);
-                FeedLoadResult snapshotResult = makeSnapshot(namespaceToSnapshot, dataSource);
+                FeedLoadResult snapshotResult = makeSnapshot(namespaceToSnapshot, dataSource, false);
                 if (storeResults) {
                     File snapshotResultFile = new File(directory, String.format("%s-snapshot.json", snapshotResult.uniqueIdentifier));
                     LOG.info("Storing validation result at {}", snapshotResultFile.getAbsolutePath());

--- a/src/main/java/com/conveyal/gtfs/loader/Table.java
+++ b/src/main/java/com/conveyal/gtfs/loader/Table.java
@@ -837,6 +837,11 @@ public class Table {
      *
      * Note: the stop_times table is a special case that will optionally normalize the stop_sequence values to be
      * zero-based and incrementing.
+     *
+     * @param connection            SQL connection
+     * @param tableToClone          table name to clone (in the dot notation: namespace.gtfs_table)
+     * @param normalizeStopTimes    whether to normalize stop times (set stop_sequence values to be zero-based and
+     *                              incrementing)
      */
     public boolean createSqlTableFrom(Connection connection, String tableToClone, boolean normalizeStopTimes) {
         long startTime = System.currentTimeMillis();

--- a/src/main/java/com/conveyal/gtfs/loader/Table.java
+++ b/src/main/java/com/conveyal/gtfs/loader/Table.java
@@ -834,8 +834,11 @@ public class Table {
     /**
      * Creates a SQL table from the table to clone. This uses the SQL syntax "create table x as y" not only copies the
      * table structure, but also the data from the original table. Creating table indexes is not handled by this method.
+     *
+     * Note: the stop_times table is a special case that will optionally normalize the stop_sequence values to be
+     * zero-based and incrementing.
      */
-    public boolean createSqlTableFrom(Connection connection, String tableToClone) {
+    public boolean createSqlTableFrom(Connection connection, String tableToClone, boolean normalizeStopTimes) {
         long startTime = System.currentTimeMillis();
         try {
             Statement statement = connection.createStatement();
@@ -843,7 +846,7 @@ public class Table {
             String dropSql = String.format("drop table if exists %s", name);
             LOG.info(dropSql);
             statement.execute(dropSql);
-            if (tableToClone.endsWith("stop_times")) {
+            if (tableToClone.endsWith("stop_times") && normalizeStopTimes) {
                 normalizeAndCloneStopTimes(statement, name, tableToClone);
             } else {
                 // Adding the unlogged keyword gives about 12 percent speedup on loading, but is non-standard.

--- a/src/test/java/com/conveyal/gtfs/GTFSTest.java
+++ b/src/test/java/com/conveyal/gtfs/GTFSTest.java
@@ -266,9 +266,7 @@ public class GTFSTest {
                     new RecordExpectation("arrival_time", 25200, "07:00:00"),
                     new RecordExpectation("departure_time", 25200, "07:00:00"),
                     new RecordExpectation("stop_id", "4u6g"),
-                    // the string expectation for stop_sequence is different because of how stop_times are
-                    // converted to 0-based indexes in Table.normalizeAndCloneStopTimes
-                    new RecordExpectation("stop_sequence", 1, "1", "0"),
+                    new RecordExpectation("stop_sequence", 1),
                     new RecordExpectation("pickup_type", 0),
                     new RecordExpectation("drop_off_type", 0),
                     new RecordExpectation("shape_dist_traveled", 0.0, 0.01)
@@ -428,21 +426,12 @@ public class GTFSTest {
 
         // Verify that making a snapshot from an existing feed database, then exporting that snapshot to a GTFS zip file
         // works as expected
-        try {
-            LOG.info("copy GTFS from created namespace");
-            SnapshotResult copyResult = GTFS.makeSnapshot(namespace, dataSource);
-            assertThatSnapshotIsErrorFree(copyResult);
-            LOG.info("export GTFS from copied namespace");
-            File tempFile = exportGtfs(copyResult.uniqueIdentifier, dataSource, true);
-            assertThatExportedGtfsMeetsExpectations(tempFile, persistenceExpectations, true);
-        } catch (IOException e) {
-            e.printStackTrace();
-            TestUtils.dropDB(testDBName);
-            return false;
-        } catch (AssertionError e) {
-            TestUtils.dropDB(testDBName);
-            throw e;
-        }
+        boolean snapshotIsOk = assertThatSnapshotIsSuccessful(namespace, dataSource, testDBName, persistenceExpectations, false);
+        if (!snapshotIsOk) return false;
+        // Also, verify that if we're normalizing stop_times#stop_sequence
+        PersistenceExpectation[] expectationsWithNormalizedStopTimes =  updatePersistenceExpectationsWithNormalizedStopTimes(persistenceExpectations);
+        boolean normalizedSnapshotIsOk = assertThatSnapshotIsSuccessful(namespace, dataSource, testDBName, expectationsWithNormalizedStopTimes, true);
+        if (!normalizedSnapshotIsOk) return false;
 
         // Verify that deleting a feed works as expected.
         try (Connection connection = dataSource.getConnection()) {
@@ -519,6 +508,31 @@ public class GTFSTest {
             this.expected = expected;
             this.found = found;
         }
+    }
+
+    private boolean assertThatSnapshotIsSuccessful(
+        String namespace,
+        DataSource dataSource,
+        String testDBName,
+        PersistenceExpectation[] persistenceExpectations,
+        boolean normalizeStopTimes
+    ) {
+        try {
+            LOG.info("copy GTFS from created namespace");
+            SnapshotResult copyResult = GTFS.makeSnapshot(namespace, dataSource, normalizeStopTimes);
+            assertThatSnapshotIsErrorFree(copyResult);
+            LOG.info("export GTFS from copied namespace");
+            File tempFile = exportGtfs(copyResult.uniqueIdentifier, dataSource, true);
+            assertThatExportedGtfsMeetsExpectations(tempFile, persistenceExpectations, true);
+        } catch (IOException e) {
+            e.printStackTrace();
+            TestUtils.dropDB(testDBName);
+            return false;
+        } catch (AssertionError e) {
+            TestUtils.dropDB(testDBName);
+            throw e;
+        }
+        return true;
     }
 
     /**
@@ -798,127 +812,147 @@ public class GTFSTest {
                 new RecordExpectation("agency_timezone", "America/Los_Angeles")
             }
         ),
-            new PersistenceExpectation(
-                "calendar",
-                new RecordExpectation[]{
-                    new RecordExpectation(
-                        "service_id", "04100312-8fe1-46a5-a9f2-556f39478f57"
-                    ),
-                    new RecordExpectation("monday", 1),
-                    new RecordExpectation("tuesday", 1),
-                    new RecordExpectation("wednesday", 1),
-                    new RecordExpectation("thursday", 1),
-                    new RecordExpectation("friday", 1),
-                    new RecordExpectation("saturday", 1),
-                    new RecordExpectation("sunday", 1),
-                    new RecordExpectation("start_date", "20170915"),
-                    new RecordExpectation("end_date", "20170917")
-                }
-            ),
-            new PersistenceExpectation(
-                "calendar_dates",
-                new RecordExpectation[]{
-                    new RecordExpectation(
-                        "service_id", "04100312-8fe1-46a5-a9f2-556f39478f57"
-                    ),
-                    new RecordExpectation("date", 20170916),
-                    new RecordExpectation("exception_type", 2)
-                }
-            ),
-            new PersistenceExpectation(
-                "fare_attributes",
-                new RecordExpectation[]{
-                    new RecordExpectation("fare_id", "route_based_fare"),
-                    new RecordExpectation("price", 1.23, 0),
-                    new RecordExpectation("currency_type", "USD")
-                }
-            ),
-            new PersistenceExpectation(
-                "fare_rules",
-                new RecordExpectation[]{
-                    new RecordExpectation("fare_id", "route_based_fare"),
-                    new RecordExpectation("route_id", "1")
-                }
-            ),
-            new PersistenceExpectation(
-                "feed_info",
-                new RecordExpectation[]{
-                    new RecordExpectation("feed_id", "fake_transit"),
-                    new RecordExpectation("feed_publisher_name", "Conveyal"),
-                    new RecordExpectation(
-                        "feed_publisher_url", "http://www.conveyal.com"
-                    ),
-                    new RecordExpectation("feed_lang", "en"),
-                    new RecordExpectation("feed_version", "1.0")
-                }
-            ),
-            new PersistenceExpectation(
-                "frequencies",
-                new RecordExpectation[]{
-                    new RecordExpectation("trip_id", "frequency-trip"),
-                    new RecordExpectation("start_time", 28800, "08:00:00"),
-                    new RecordExpectation("end_time", 32400, "09:00:00"),
-                    new RecordExpectation("headway_secs", 1800),
-                    new RecordExpectation("exact_times", 0)
-                }
-            ),
-            new PersistenceExpectation(
-                "routes",
-                new RecordExpectation[]{
-                    new RecordExpectation("agency_id", "1"),
-                    new RecordExpectation("route_id", "1"),
-                    new RecordExpectation("route_short_name", "1"),
-                    new RecordExpectation("route_long_name", "Route 1"),
-                    new RecordExpectation("route_type", 3),
-                    new RecordExpectation("route_color", "7CE6E7")
-                }
-            ),
-            new PersistenceExpectation(
-                "shapes",
-                new RecordExpectation[]{
-                    new RecordExpectation(
-                        "shape_id", "5820f377-f947-4728-ac29-ac0102cbc34e"
-                    ),
-                    new RecordExpectation("shape_pt_lat", 37.061172, 0.00001),
-                    new RecordExpectation("shape_pt_lon", -122.007500, 0.00001),
-                    new RecordExpectation("shape_pt_sequence", 2),
-                    new RecordExpectation("shape_dist_traveled", 7.4997067, 0.01)
-                }
-            ),
-            new PersistenceExpectation(
-                "stop_times",
-                new RecordExpectation[]{
-                    new RecordExpectation(
-                        "trip_id", "a30277f8-e50a-4a85-9141-b1e0da9d429d"
-                    ),
-                    new RecordExpectation("arrival_time", 25200, "07:00:00"),
-                    new RecordExpectation("departure_time", 25200, "07:00:00"),
-                    new RecordExpectation("stop_id", "4u6g"),
-                    // the string expectation for stop_sequence is different because of how stop_times are
-                    // converted to 0-based indexes in Table.normalizeAndCloneStopTimes
-                    new RecordExpectation("stop_sequence", 1, "1", "0"),
-                    new RecordExpectation("pickup_type", 0),
-                    new RecordExpectation("drop_off_type", 0),
-                    new RecordExpectation("shape_dist_traveled", 0.0, 0.01)
-                }
-            ),
-            new PersistenceExpectation(
-                "trips",
-                new RecordExpectation[]{
-                    new RecordExpectation(
-                        "trip_id", "a30277f8-e50a-4a85-9141-b1e0da9d429d"
-                    ),
-                    new RecordExpectation(
-                        "service_id", "04100312-8fe1-46a5-a9f2-556f39478f57"
-                    ),
-                    new RecordExpectation("route_id", "1"),
-                    new RecordExpectation("direction_id", 0),
-                    new RecordExpectation(
-                        "shape_id", "5820f377-f947-4728-ac29-ac0102cbc34e"
-                    ),
-                    new RecordExpectation("bikes_allowed", 0),
-                    new RecordExpectation("wheelchair_accessible", 0)
-                }
-            )
+        new PersistenceExpectation(
+            "calendar",
+            new RecordExpectation[]{
+                new RecordExpectation(
+                    "service_id", "04100312-8fe1-46a5-a9f2-556f39478f57"
+                ),
+                new RecordExpectation("monday", 1),
+                new RecordExpectation("tuesday", 1),
+                new RecordExpectation("wednesday", 1),
+                new RecordExpectation("thursday", 1),
+                new RecordExpectation("friday", 1),
+                new RecordExpectation("saturday", 1),
+                new RecordExpectation("sunday", 1),
+                new RecordExpectation("start_date", "20170915"),
+                new RecordExpectation("end_date", "20170917")
+            }
+        ),
+        new PersistenceExpectation(
+            "calendar_dates",
+            new RecordExpectation[]{
+                new RecordExpectation(
+                    "service_id", "04100312-8fe1-46a5-a9f2-556f39478f57"
+                ),
+                new RecordExpectation("date", 20170916),
+                new RecordExpectation("exception_type", 2)
+            }
+        ),
+        new PersistenceExpectation(
+            "fare_attributes",
+            new RecordExpectation[]{
+                new RecordExpectation("fare_id", "route_based_fare"),
+                new RecordExpectation("price", 1.23, 0),
+                new RecordExpectation("currency_type", "USD")
+            }
+        ),
+        new PersistenceExpectation(
+            "fare_rules",
+            new RecordExpectation[]{
+                new RecordExpectation("fare_id", "route_based_fare"),
+                new RecordExpectation("route_id", "1")
+            }
+        ),
+        new PersistenceExpectation(
+            "feed_info",
+            new RecordExpectation[]{
+                new RecordExpectation("feed_id", "fake_transit"),
+                new RecordExpectation("feed_publisher_name", "Conveyal"),
+                new RecordExpectation(
+                    "feed_publisher_url", "http://www.conveyal.com"
+                ),
+                new RecordExpectation("feed_lang", "en"),
+                new RecordExpectation("feed_version", "1.0")
+            }
+        ),
+        new PersistenceExpectation(
+            "frequencies",
+            new RecordExpectation[]{
+                new RecordExpectation("trip_id", "frequency-trip"),
+                new RecordExpectation("start_time", 28800, "08:00:00"),
+                new RecordExpectation("end_time", 32400, "09:00:00"),
+                new RecordExpectation("headway_secs", 1800),
+                new RecordExpectation("exact_times", 0)
+            }
+        ),
+        new PersistenceExpectation(
+            "routes",
+            new RecordExpectation[]{
+                new RecordExpectation("agency_id", "1"),
+                new RecordExpectation("route_id", "1"),
+                new RecordExpectation("route_short_name", "1"),
+                new RecordExpectation("route_long_name", "Route 1"),
+                new RecordExpectation("route_type", 3),
+                new RecordExpectation("route_color", "7CE6E7")
+            }
+        ),
+        new PersistenceExpectation(
+            "shapes",
+            new RecordExpectation[]{
+                new RecordExpectation(
+                    "shape_id", "5820f377-f947-4728-ac29-ac0102cbc34e"
+                ),
+                new RecordExpectation("shape_pt_lat", 37.061172, 0.00001),
+                new RecordExpectation("shape_pt_lon", -122.007500, 0.00001),
+                new RecordExpectation("shape_pt_sequence", 2),
+                new RecordExpectation("shape_dist_traveled", 7.4997067, 0.01)
+            }
+        ),
+        new PersistenceExpectation(
+            "stop_times",
+            new RecordExpectation[]{
+                new RecordExpectation(
+                    "trip_id", "a30277f8-e50a-4a85-9141-b1e0da9d429d"
+                ),
+                new RecordExpectation("arrival_time", 25200, "07:00:00"),
+                new RecordExpectation("departure_time", 25200, "07:00:00"),
+                new RecordExpectation("stop_id", "4u6g"),
+                new RecordExpectation("stop_sequence", 1),
+                new RecordExpectation("pickup_type", 0),
+                new RecordExpectation("drop_off_type", 0),
+                new RecordExpectation("shape_dist_traveled", 0.0, 0.01)
+            }
+        ),
+        new PersistenceExpectation(
+            "trips",
+            new RecordExpectation[]{
+                new RecordExpectation(
+                    "trip_id", "a30277f8-e50a-4a85-9141-b1e0da9d429d"
+                ),
+                new RecordExpectation(
+                    "service_id", "04100312-8fe1-46a5-a9f2-556f39478f57"
+                ),
+                new RecordExpectation("route_id", "1"),
+                new RecordExpectation("direction_id", 0),
+                new RecordExpectation(
+                    "shape_id", "5820f377-f947-4728-ac29-ac0102cbc34e"
+                ),
+                new RecordExpectation("bikes_allowed", 0),
+                new RecordExpectation("wheelchair_accessible", 0)
+            }
+        )
     };
+
+    /**
+     * Update persistence expectations to expect normalized stop_sequence values.
+     */
+    private PersistenceExpectation[] updatePersistenceExpectationsWithNormalizedStopTimes(PersistenceExpectation[] inputExpectations) {
+        PersistenceExpectation[] persistenceExpectations = new PersistenceExpectation[inputExpectations.length];
+        // Add all of the table expectations.
+        for (int i = 0; i < inputExpectations.length; i++) {
+            // Collect record expectations.
+            RecordExpectation[] newRecordExpectations = new RecordExpectation[inputExpectations[i].recordExpectations.length];
+            for (int j = 0; j < inputExpectations[i].recordExpectations.length; j++) {
+                newRecordExpectations[j] = inputExpectations[i].recordExpectations[j].clone();
+                // Update the stop_sequence expectation to be normalized.
+                if (newRecordExpectations[j].fieldName.equals("stop_sequence")) {
+                    newRecordExpectations[j].intExpectation = 0;
+                }
+            }
+
+            persistenceExpectations[i] = new PersistenceExpectation(inputExpectations[i].tableName, newRecordExpectations);
+        }
+        return persistenceExpectations;
+    }
 }

--- a/src/test/java/com/conveyal/gtfs/loader/JDBCTableWriterTest.java
+++ b/src/test/java/com/conveyal/gtfs/loader/JDBCTableWriterTest.java
@@ -84,7 +84,7 @@ public class JDBCTableWriterTest {
         connection.commit();
         LOG.info("feeds table created");
         // Create an empty snapshot to create a new namespace and all the tables
-        FeedLoadResult result = makeSnapshot(null, testDataSource);
+        FeedLoadResult result = makeSnapshot(null, testDataSource, false);
         testNamespace = result.uniqueIdentifier;
         // Create a service calendar and two stops, both of which are necessary to perform pattern and trip tests.
         createWeekdayCalendar(simpleServiceId, "20180103", "20180104");
@@ -98,7 +98,7 @@ public class JDBCTableWriterTest {
         // validate feed to create additional tables
         validate(testGtfsGLNamespace, testDataSource);
         // load into editor via snapshot
-        JdbcGtfsSnapshotter snapshotter = new JdbcGtfsSnapshotter(testGtfsGLNamespace, testDataSource);
+        JdbcGtfsSnapshotter snapshotter = new JdbcGtfsSnapshotter(testGtfsGLNamespace, testDataSource, false);
         SnapshotResult snapshotResult = snapshotter.copyTables();
         testGtfsGLSnapshotNamespace = snapshotResult.uniqueIdentifier;
     }

--- a/src/test/java/com/conveyal/gtfs/storage/RecordExpectation.java
+++ b/src/test/java/com/conveyal/gtfs/storage/RecordExpectation.java
@@ -64,6 +64,11 @@ public class RecordExpectation {
         this.acceptedDelta = acceptedDelta;
     }
 
+    /** Constructor only used for {@link #clone}. */
+    private RecordExpectation(String fieldname) {
+        this.fieldName = fieldname;
+    }
+
     public String getStringifiedExpectation(boolean fromEditor) {
         if (fromEditor && editorStringExpectation) return editorExpectation;
         if (stringExpectationInCSV) return stringExpectation;
@@ -77,5 +82,18 @@ public class RecordExpectation {
             default:
                 return null;
         }
+    }
+
+    /** Clone a record expectation. Note: new fields should be added here. */
+    public RecordExpectation clone() {
+        RecordExpectation copy = new RecordExpectation(this.fieldName);
+        copy.expectedFieldType = this.expectedFieldType;
+        copy.editorExpectation = this.editorExpectation;
+        copy.intExpectation = this.intExpectation;
+        copy.stringExpectation = this.stringExpectation;
+        copy.stringExpectationInCSV = this.stringExpectationInCSV;
+        copy.acceptedDelta = this.acceptedDelta;
+        copy.doubleExpectation = this.doubleExpectation;
+        return copy;
     }
 }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

re #283