### PR TITLE
Silence number excessive parse exceptions logs

### DIFF
--- a/src/main/java/com/conveyal/gtfs/error/NewGTFSError.java
+++ b/src/main/java/com/conveyal/gtfs/error/NewGTFSError.java
@@ -2,6 +2,8 @@ package com.conveyal.gtfs.error;
 
 import com.conveyal.gtfs.loader.Table;
 import com.conveyal.gtfs.model.Entity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -15,7 +17,7 @@ import java.util.Map;
  * We instead use an enum with final fields for severity and affected entity type.
  */
 public class NewGTFSError {
-
+    private static final Logger LOG = LoggerFactory.getLogger(NewGTFSError.class);
     /** The class of the table in which the error was encountered. */
     public Class<? extends Entity> entityType;
 
@@ -111,15 +113,23 @@ public class NewGTFSError {
         return this;
     }
 
-    // Builder to add entity sequence info from string (values during load stage are passed in as strings from csv
-    // reader)
+    /**
+     * Builder to add entity sequence info from string (values during load stage are passed in as strings from csv
+     * reader).
+     */
     public NewGTFSError setSequence(String sequenceAsString) {
-        try {
-            // Parse int from string value found during load stage.
-            this.entitySequenceNumber = Integer.parseInt(sequenceAsString);
-        } catch (NumberFormatException e) {
-            e.printStackTrace();
+        if (sequenceAsString == null || sequenceAsString.isEmpty()) {
+            // Skip parsing of value if null or empty string literal.
             this.entitySequenceNumber = null;
+        } else {
+            // Otherwise, attempt to parse value.
+            try {
+                // Parse int from string value found during load stage.
+                this.entitySequenceNumber = Integer.parseInt(sequenceAsString);
+            } catch (NumberFormatException e) {
+                LOG.warn("Could not parse int for value: '{}'", sequenceAsString);
+                this.entitySequenceNumber = null;
+            }
         }
         return this;
     }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

There are a large number of useless exceptions being output to the log when adding NewGtfsError entries that do not have sequence values. This attempts to silence most of those. re ibi-group/datatools-server#342
