### PR TITLE
Handle empty strings

### DIFF
--- a/src/test/java/com/conveyal/gtfs/dto/RouteDTO.java
+++ b/src/test/java/com/conveyal/gtfs/dto/RouteDTO.java
@@ -21,6 +21,7 @@ public class RouteDTO {
     public String route_text_color;
     public Integer publicly_visible;
     public Integer wheelchair_accessible;
-    public Integer route_sort_order;
+    /** This field is incorrectly set to String in order to test how empty string literals are persisted to the database. */
+    public String route_sort_order;
     public Integer status;
 }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR addresses ibi-group/datatools-ui#619 and ibi-group/datatools-ui#616 by better handling empty string values passed to JdbcTableWriter for updates to GTFS entities. It also enhances tests to verify that `trip_id` is auto-generated for empty string literals.