### PR TITLE
Add GH_TOKEN variable for semantic-release

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -67,6 +67,8 @@ jobs:
           #
       # The git commands get the commit hash of the HEAD commit and the commit just before HEAD.
     - name: Run maven-semantic-release
+      env:
+        GH_TOKEN: ${{ secrets.GH_TOKEN }}
       run: |
        semantic-release --prepare @conveyal/maven-semantic-release --publish @semantic-release/github,@conveyal/maven-semantic-release --verify-conditions @semantic-release/github,@conveyal/maven-semantic-release --verify-release @conveyal/maven-semantic-release --use-conveyal-workflow --dev-branch=dev --skip-maven-deploy
        if [[ "$GITHUB_REF_SLUG" = "master" ]]; then


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

fix #306 by adding the `GH_TOKEN` env variable to the release step.