### PR TITLE
Update conditional requirements checks

### DIFF
--- a/src/main/java/com/conveyal/gtfs/error/NewGTFSError.java
+++ b/src/main/java/com/conveyal/gtfs/error/NewGTFSError.java
@@ -1,5 +1,6 @@
 package com.conveyal.gtfs.error;
 
+import com.conveyal.gtfs.loader.LineContext;
 import com.conveyal.gtfs.loader.Table;
 import com.conveyal.gtfs.model.Entity;
 import org.slf4j.Logger;
@@ -78,6 +79,14 @@ public class NewGTFSError {
     public static NewGTFSError forLine (Table table, int lineNumber, NewGTFSErrorType errorType, String badValue) {
         NewGTFSError error = new NewGTFSError(table.getEntityClass(), errorType);
         error.lineNumber = lineNumber;
+        error.badValue = badValue;
+        return error;
+    }
+
+    // Factory Builder for cases where an entity has not yet been constructed, but we know the line number.
+    public static NewGTFSError forLine (LineContext lineContext, NewGTFSErrorType errorType, String badValue) {
+        NewGTFSError error = new NewGTFSError(lineContext.table.getEntityClass(), errorType);
+        error.lineNumber = lineContext.lineNumber;
         error.badValue = badValue;
         return error;
     }

--- a/src/main/java/com/conveyal/gtfs/error/NewGTFSErrorType.java
+++ b/src/main/java/com/conveyal/gtfs/error/NewGTFSErrorType.java
@@ -8,7 +8,7 @@ import com.conveyal.gtfs.validator.model.Priority;
  */
 public enum NewGTFSErrorType {
     // Standard errors.
-    AGENCY_ID_REQUIRED_FOR_TABLES_WITH_MORE_THAN_ONE_RECORD(Priority.HIGH, "For GTFS feeds with more than one agency, agency_id is required."),
+    AGENCY_ID_REQUIRED_FOR_MULTI_AGENCY_FEEDS(Priority.HIGH, "For GTFS feeds with more than one agency, agency_id is required."),
     BOOLEAN_FORMAT(Priority.MEDIUM, "A GTFS boolean field must contain the value 1 or 0."),
     COLOR_FORMAT(Priority.MEDIUM, "A color should be specified with six-characters (three two-digit hexadecimal numbers)."),
     COLUMN_NAME_UNSAFE(Priority.HIGH, "Column header contains characters not safe in SQL, it was renamed."),

--- a/src/main/java/com/conveyal/gtfs/loader/ConditionalCheckType.java
+++ b/src/main/java/com/conveyal/gtfs/loader/ConditionalCheckType.java
@@ -8,7 +8,7 @@ public enum ConditionalCheckType {
     /**
      * The conditionally required field value must not be empty. This is used in conjunction with
      * {@link ConditionalCheckType#FIELD_IN_RANGE}. E.g. if the reference field is within a specified range, the
-     * conditionally required field must not be empty.
+     * dependent field must not be empty.
      */
     FIELD_NOT_EMPTY,
     /**
@@ -16,12 +16,12 @@ public enum ConditionalCheckType {
      */
     FIELD_IN_RANGE,
     /**
-     * The reference field value must be available in order to match the conditionally required field value.
+     * This checks that the foreign reference exists in the dependent field (e.g., stops#zone_id).
      */
-    FOREIGN_FIELD_VALUE_MATCH,
+    FOREIGN_REF_EXISTS,
     /**
-     * If the reference table row count is greater than one, the conditionally required field values must not be empty.
-     * This is used in conjunction with {@link ConditionalCheckType#FIELD_NOT_EMPTY}.
+     * Check that the reference table has multiple records. This is sometimes used in conjunction with
+     * {@link ConditionalCheckType#FIELD_NOT_EMPTY} (e.g., to check that multiple agencies exist).
      */
-    ROW_COUNT_GREATER_THAN_ONE
+    HAS_MULTIPLE_ROWS
 }

--- a/src/main/java/com/conveyal/gtfs/loader/ConditionalRequirement.java
+++ b/src/main/java/com/conveyal/gtfs/loader/ConditionalRequirement.java
@@ -1,120 +1,132 @@
 package com.conveyal.gtfs.loader;
 
 import com.conveyal.gtfs.error.NewGTFSError;
+import com.google.common.collect.TreeMultimap;
 
 import java.util.HashSet;
+import java.util.NavigableSet;
 import java.util.Set;
 
-import static com.conveyal.gtfs.error.NewGTFSErrorType.AGENCY_ID_REQUIRED_FOR_TABLES_WITH_MORE_THAN_ONE_RECORD;
+import static com.conveyal.gtfs.error.NewGTFSErrorType.AGENCY_ID_REQUIRED_FOR_MULTI_AGENCY_FEEDS;
 import static com.conveyal.gtfs.error.NewGTFSErrorType.CONDITIONALLY_REQUIRED;
+import static com.conveyal.gtfs.error.NewGTFSErrorType.REFERENTIAL_INTEGRITY;
 import static com.conveyal.gtfs.loader.ConditionalCheckType.FIELD_NOT_EMPTY;
+import static com.conveyal.gtfs.loader.ConditionalCheckType.HAS_MULTIPLE_ROWS;
 import static com.conveyal.gtfs.loader.JdbcGtfsLoader.POSTGRES_NULL_TEXT;
 
 /**
- * These are the values that are checked inline with {@link ConditionalCheckType} to determine if the required
- * conditions have been met.
+ * These are the requirements that are checked inline with {@link ConditionalCheckType} to determine if the required
+ * conditions set forth for certain fields in the GTFS spec have been met. These requirements are applied directly to
+ * their "reference fields" with the help of {@link Field#requireConditions}.
  */
 public class ConditionalRequirement {
-    /** The type of check to be performed on a reference field. A reference field value is used to determine whether or
-     * not a conditional field is required. */
-    public ConditionalCheckType referenceCheck;
+    private static final int FIRST_ROW = 2;
+    private static final int SECOND_ROW = 3;
+    /** The type of check to be performed on a reference field. A reference field value is used to determine which check
+     * (e.g., {@link #checkHasMultipleRows}) should be applied to the field. */
+    public ConditionalCheckType referenceFieldCheck;
     /** The minimum reference field value if a range check is being performed. */
     public int minReferenceValue;
     /** The maximum reference field value if a range check is being performed. */
     public int maxReferenceValue;
-    /** The type of check to be performed on a conditional field. A conditional field is one that may require a value
-     * if the reference and conditional checks met certain conditions. */
-    public ConditionalCheckType conditionalCheck;
-    /** The name of the conditional field. */
-    public String conditionalFieldName;
+    /** The type of check to be performed on the dependent field. */
+    public ConditionalCheckType dependentFieldCheck;
+    /** The name of the dependent field, which is a field that requires a specific value if the reference and
+     * (in some cases) dependent field checks meet certain conditions.*/
+    public String dependentFieldName;
 
     public ConditionalRequirement(
         int minReferenceValue,
         int maxReferenceValue,
-        String conditionalFieldName,
-        ConditionalCheckType conditionalCheck,
-        ConditionalCheckType referenceCheck
+        String dependentFieldName,
+        ConditionalCheckType dependentFieldCheck,
+        ConditionalCheckType referenceFieldCheck
 
     ) {
         this.minReferenceValue = minReferenceValue;
         this.maxReferenceValue = maxReferenceValue;
-        this.conditionalFieldName = conditionalFieldName;
-        this.conditionalCheck = conditionalCheck;
-        this.referenceCheck = referenceCheck;
+        this.dependentFieldName = dependentFieldName;
+        this.dependentFieldCheck = dependentFieldCheck;
+        this.referenceFieldCheck = referenceFieldCheck;
     }
 
     public ConditionalRequirement(
-        String conditionalFieldName,
-        ConditionalCheckType referenceCheck
+        String dependentFieldName,
+        ConditionalCheckType referenceFieldCheck
     ) {
-        this(0,0, conditionalFieldName, null, referenceCheck);
+        this(0,0, dependentFieldName, null, referenceFieldCheck);
     }
 
     public ConditionalRequirement(
-        String conditionalFieldName,
-        ConditionalCheckType conditionalCheck,
-        ConditionalCheckType referenceCheck
+        String dependentFieldName,
+        ConditionalCheckType dependentFieldCheck,
+        ConditionalCheckType referenceFieldCheck
     ) {
-        this(0,0, conditionalFieldName, conditionalCheck, referenceCheck);
+        this(0,0, dependentFieldName, dependentFieldCheck, referenceFieldCheck);
     }
 
     /**
-     * Flag an error if the number of rows in the agency table is greater than one and the agency_id has not been defined
-     * for each row.
+     * Flag an error if there are multiple rows (designed for agency.txt) and the agency_id is missing for any rows.
      */
-    public static Set<NewGTFSError> checkRowCountGreaterThanOne(
-        Table table,
-        int lineNumber,
-        Set<String> transitIds,
-        ConditionalRequirement check,
-        String conditionalFieldValue,
-        String entityId
+    public static Set<NewGTFSError> checkHasMultipleRows(
+        LineContext lineContext,
+        TreeMultimap<String, String> uniqueValuesForFields,
+        ConditionalRequirement check
     ) {
+        String dependentFieldValue = lineContext.getValueForRow(check.dependentFieldName);
         Set<NewGTFSError> errors = new HashSet<>();
-        if (table.name.equals("agency") &&
-            lineNumber > 2 &&
-            transitIds
-                .stream()
-                .filter(transitId -> transitId.contains("agency_id"))
-                .count() != lineNumber - 1
-        ) {
+        NavigableSet<String> agencyIdValues = uniqueValuesForFields.get(check.dependentFieldName);
+        // Do some awkward checks to determine if the first or second row (or another) is missing the agency_id.
+        boolean firstOrSecondMissingId = lineContext.lineNumber == SECOND_ROW && agencyIdValues.contains("");
+        boolean currentRowMissingId = POSTGRES_NULL_TEXT.equals(dependentFieldValue);
+        boolean secondRowMissingId = firstOrSecondMissingId && currentRowMissingId;
+        if (firstOrSecondMissingId || (lineContext.lineNumber > SECOND_ROW && currentRowMissingId)) {
             // The check on the agency table is carried out whilst the agency table is being loaded so it
             // is possible to compare the number of transitIds added against the number of rows loaded to
             // accurately determine missing agency_id values.
-            String message = String.format(
-                "%s is conditionally required when there is more than one agency.",
-                check.conditionalFieldName
-            );
-            errors.add(
-                NewGTFSError.forLine(table, lineNumber, CONDITIONALLY_REQUIRED, message)
-            );
-        } else if (
-            (
-                table.name.equals("routes") ||
-                table.name.equals("fare_attributes")
-            ) &&
-                transitIds
-                    .stream()
-                    .filter(transitId -> transitId.contains("agency_id"))
-                    .count() > 1 &&
-                check.conditionalCheck == FIELD_NOT_EMPTY &&
-                POSTGRES_NULL_TEXT.equals(conditionalFieldValue)
-        ) {
-            // By this point the agency table has already been loaded, therefore, if the number of agency_id
-            // transitIds is greater than one it is assumed more than one agency has been provided.
-            // FIXME: This doesn't work if only one agency_id is defined in the agency table. e.g. 2 rows of
-            //  data, but the first doesn't define an agency_id.
-            String message = String.format(
-                "%s is conditionally required when there is more than one agency.",
-                check.conditionalFieldName
-            );
+            int lineNumber = secondRowMissingId
+                ? SECOND_ROW
+                : firstOrSecondMissingId
+                    ? FIRST_ROW
+                    : lineContext.lineNumber;
             errors.add(
                 NewGTFSError.forLine(
-                    table,
+                    lineContext.table,
                     lineNumber,
-                    AGENCY_ID_REQUIRED_FOR_TABLES_WITH_MORE_THAN_ONE_RECORD,
-                    message).setEntityId(entityId)
+                    AGENCY_ID_REQUIRED_FOR_MULTI_AGENCY_FEEDS,
+                    check.dependentFieldName
+                )
             );
+        }
+        return errors;
+    }
+
+    /**
+     * Checks that the reference field is not empty when the dependent field/table has multiple rows. This is
+     * principally designed for checking that routes#agency_id is filled when multiple agencies exist.
+     */
+    public static Set<NewGTFSError> checkFieldEmpty(
+        LineContext lineContext,
+        Field referenceField,
+        TreeMultimap<String, String> uniqueValuesForFields,
+        ConditionalRequirement check
+    ) {
+        String referenceFieldValue = lineContext.getValueForRow(referenceField.name);
+        Set<NewGTFSError> errors = new HashSet<>();
+        int dependentFieldCount = uniqueValuesForFields.get(check.dependentFieldName).size();
+        if (check.dependentFieldCheck == HAS_MULTIPLE_ROWS && dependentFieldCount > 1) {
+            // If there are multiple entries for the dependent field (including empty strings to account for any
+            // potentially missing values), the reference field must not be empty.
+            boolean referenceFieldIsEmpty = POSTGRES_NULL_TEXT.equals(referenceFieldValue);
+            if (referenceFieldIsEmpty) {
+                errors.add(
+                    NewGTFSError.forLine(
+                        lineContext,
+                        AGENCY_ID_REQUIRED_FOR_MULTI_AGENCY_FEEDS,
+                        null
+                    ).setEntityId(lineContext.getEntityId())
+                );
+            }
         }
         return errors;
     }
@@ -124,16 +136,13 @@ public class ConditionalRequirement {
      * an error.
      */
     public static Set<NewGTFSError> checkFieldInRange(
-        Table table,
-        int lineNumber,
+        LineContext lineContext,
         Field referenceField,
-        ConditionalRequirement check,
-        String referenceFieldValue,
-        String conditionalFieldValue,
-        String entityId
+        ConditionalRequirement check
     ) {
         Set<NewGTFSError> errors = new HashSet<>();
-
+        String referenceFieldValue = lineContext.getValueForRow(referenceField.name);
+        String conditionalFieldValue = lineContext.getValueForRow(check.dependentFieldName);
         boolean referenceValueMeetsRangeCondition =
             !POSTGRES_NULL_TEXT.equals(referenceFieldValue) &&
                 // TODO use pre-existing method in ShortField?
@@ -145,24 +154,23 @@ public class ConditionalRequirement {
             return errors;
         }
         boolean conditionallyRequiredValueIsEmpty =
-            check.conditionalCheck == FIELD_NOT_EMPTY &&
+            check.dependentFieldCheck == FIELD_NOT_EMPTY &&
                 POSTGRES_NULL_TEXT.equals(conditionalFieldValue);
 
         if (conditionallyRequiredValueIsEmpty) {
             // Reference value in range and conditionally required field is empty.
             String message = String.format(
                 "%s is conditionally required when %s value is between %d and %d.",
-                check.conditionalFieldName,
+                check.dependentFieldName,
                 referenceField.name,
                 check.minReferenceValue,
                 check.maxReferenceValue
             );
             errors.add(
                 NewGTFSError.forLine(
-                    table,
-                    lineNumber,
+                    lineContext,
                     CONDITIONALLY_REQUIRED,
-                    message).setEntityId(entityId)
+                    message).setEntityId(lineContext.getEntityId())
             );
         }
         return errors;
@@ -170,46 +178,35 @@ public class ConditionalRequirement {
 
     /**
      * Check that an expected foreign field value matches a conditional field value. Selected foreign field values are
-     * added to {@link ReferenceTracker#foreignFieldIds} as part of the load process and are used here to check
+     * added to {@link ReferenceTracker#uniqueValuesForFields} as part of the load process and are used here to check
      * conditional fields which have a dependency on them.
      */
-    public static Set<NewGTFSError> checkForeignFieldValueMatch(
-        Table table,
-        int lineNumber,
+    public static Set<NewGTFSError> checkForeignRefExists(
+        LineContext lineContext,
         Field referenceField,
         ConditionalRequirement check,
-        String referenceFieldValue,
-        Set<String> foreignFieldIds,
-        String entityId
+        TreeMultimap<String, String> uniqueValuesForFields
     ) {
         Set<NewGTFSError> errors = new HashSet<>();
+        String referenceFieldValue = lineContext.getValueForRow(referenceField.name);
         // Expected reference in foreign field id list.
         String foreignFieldReference =
             String.join(
                 ":",
-                check.conditionalFieldName,
+                check.dependentFieldName,
                 referenceFieldValue
             );
-        if (table.name.equals("fare_rules") &&
+        if (lineContext.table.name.equals("fare_rules") &&
             !POSTGRES_NULL_TEXT.equals(referenceFieldValue) &&
-            foreignFieldIds
-                .stream()
-                .noneMatch(id -> id.contains(foreignFieldReference))
+            !uniqueValuesForFields.get(check.dependentFieldName).contains(foreignFieldReference)
         ) {
-            // The foreign key reference required by fields in fare rules is not available in stops.
-            String message = String.format(
-                "%s %s is conditionally required in stops when referenced by %s in %s.",
-                check.conditionalFieldName,
-                referenceFieldValue,
-                referenceField.name,
-                table.name
-            );
+            // stop#zone_id does not exist in stops table, but is required by fare_rules records (e.g., origin_id).
             errors.add(
                 NewGTFSError.forLine(
-                    table,
-                    lineNumber,
-                    CONDITIONALLY_REQUIRED,
-                    message).setEntityId(entityId)
+                    lineContext,
+                    REFERENTIAL_INTEGRITY,
+                    String.join(":", referenceField.name, foreignFieldReference)
+                ).setEntityId(lineContext.getEntityId())
             );
         }
         return errors;

--- a/src/main/java/com/conveyal/gtfs/loader/Field.java
+++ b/src/main/java/com/conveyal/gtfs/loader/Field.java
@@ -141,6 +141,25 @@ public abstract class Field {
     }
 
     /**
+     * Fluent method to flag field as having foreign references. If flagged, the field value is added to
+     * {@link ReferenceTracker#uniqueValuesForFields} to be used as a look-up for reference matches. Note: this is intended only for
+     * special cases (e.g., zone_id) where the field being referenced does not exist as the primary key of a table.
+     */
+    Field hasForeignReferences() {
+        isForeign = true;
+        return this;
+    }
+
+    /**
+     * Indicates that this field has foreign references. Note: this is intentionally distinct from
+     * {@link #isForeignReference()} and is intended only for special cases (e.g., zone_id) where the field being
+     * referenced does not exist as the primary key of a table.
+     */
+    public boolean isForeign() {
+        return isForeign;
+    }
+
+    /**
      * Fluent method that indicates that a newly constructed field should be indexed after the table is loaded.
      * FIXME: should shouldBeIndexed be determined based on presence of referenceTable?
      * @return this same Field instance, which allows constructing and assigning the instance in the same statement.
@@ -155,7 +174,8 @@ public abstract class Field {
     }
 
     /**
-     * Fluent method indicates that this field is a reference to an entry in the table provided as an argument.
+     * Fluent method indicates that this field is a reference to an entry in the table provided as an argument (i.e., it
+     * is a foreign reference).
      * @param table
      * @return this same Field instance
      */
@@ -204,21 +224,5 @@ public abstract class Field {
      */
     public boolean isConditionallyRequired() {
         return isConditionallyRequired;
-    }
-
-    /**
-     * Flag this field as a foreign reference. If flagged the field value is added to
-     * {@link ReferenceTracker#foreignFieldIds} to be used as a look-up for reference matches.
-     */
-    public Field foreign() {
-        isForeign = true;
-        return this;
-    }
-
-    /**
-     * Indicates that this field is required as a foreign reference.
-     */
-    public boolean isForeign() {
-        return isForeign;
     }
 }

--- a/src/main/java/com/conveyal/gtfs/loader/JdbcGtfsLoader.java
+++ b/src/main/java/com/conveyal/gtfs/loader/JdbcGtfsLoader.java
@@ -376,6 +376,7 @@ public class JdbcGtfsLoader {
                 errorStorage.storeError(NewGTFSError.forTable(table, TABLE_TOO_LONG));
                 break;
             }
+            // Line 1 is considered the header row, so the first actual row of data will be line 2.
             int lineNumber = ((int) csvReader.getCurrentRecord()) + 2;
             if (lineNumber % 500_000 == 0) LOG.info("Processed {}", human(lineNumber));
             if (csvReader.getColumnCount() != fields.length) {
@@ -434,8 +435,9 @@ public class JdbcGtfsLoader {
                 columnIndex += 1;
             }
             if (tableHasConditions) {
+                LineContext lineContext = new LineContext(table, fields, transformedStrings, lineNumber);
                 errorStorage.storeErrors(
-                    referenceTracker.checkConditionallyRequiredFields(table, fields, transformedStrings, lineNumber)
+                    referenceTracker.checkConditionallyRequiredFields(lineContext)
                 );
             }
             if (postgresText) {

--- a/src/main/java/com/conveyal/gtfs/loader/LineContext.java
+++ b/src/main/java/com/conveyal/gtfs/loader/LineContext.java
@@ -1,0 +1,43 @@
+package com.conveyal.gtfs.loader;
+
+/**
+ * Wrapper class that provides access to row values and line context (e.g., line number) for a particular row of GTFS
+ * data.
+ */
+public class LineContext {
+    public final Table table;
+    private final Field[] fields;
+    private final String[] rowData;
+    public final int lineNumber;
+
+    public LineContext(Table table, Field[] fields, String[] rowData, int lineNumber) {
+        this.table = table;
+        this.fields = fields;
+        this.rowData = rowData;
+        this.lineNumber = lineNumber;
+    }
+
+    /**
+     * Get value for a particular column index from a set of row data. Note: the row data here has one extra value at
+     * the beginning of the array that represents the line number (hence the +1). This is because the data is formatted
+     * for batch insertion into a postgres table.
+     */
+    public String getValueForRow(int columnIndex) {
+        return rowData[columnIndex + 1];
+    }
+
+    /**
+     * Overloaded method to provide value for the current line for a particular field.
+     */
+    public String getValueForRow(String fieldName) {
+        int fieldIndex = Field.getFieldIndex(fields, fieldName);
+        return rowData[fieldIndex + 1];
+    }
+
+    /**
+     * Overloaded method to provide value for the current line for the key field.
+     */
+    public String getEntityId() {
+        return getValueForRow(table.getKeyFieldIndex(fields));
+    }
+}

--- a/src/main/java/com/conveyal/gtfs/loader/ReferenceTracker.java
+++ b/src/main/java/com/conveyal/gtfs/loader/ReferenceTracker.java
@@ -1,6 +1,7 @@
 package com.conveyal.gtfs.loader;
 
 import com.conveyal.gtfs.error.NewGTFSError;
+import com.google.common.collect.TreeMultimap;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -22,7 +23,7 @@ import static com.conveyal.gtfs.error.NewGTFSErrorType.REFERENTIAL_INTEGRITY;
  */
 public class ReferenceTracker {
     public final Set<String> transitIds = new HashSet<>();
-    public final Set<String> foreignFieldIds = new HashSet<>();
+    public final TreeMultimap<String, String> uniqueValuesForFields = TreeMultimap.create();
     public final Set<String> transitIdsWithSequence = new HashSet<>();
 
     /**
@@ -64,9 +65,11 @@ public class ReferenceTracker {
             : !table.hasUniqueKeyField ? null : keyField;
         String transitId = String.join(":", keyField, keyValue);
 
-        // Field value is required for referential integrity checks as part of conditionally required checks.
-        if (!"".equals(value) && field.isForeign()) {
-            foreignFieldIds.add(String.join(":", field.name, value));
+        // Unique key values are needed for referential integrity checks as part of checks for fields that have
+        // conditional requirements. This also tracks "special" foreign keys like stop#zone_id that are not primary keys
+        // of the table they exist in.
+        if ((field.name.equals(keyField) && keyField.equals(uniqueKeyField)) || field.isForeign()) {
+            uniqueValuesForFields.put(field.name, value);
         }
 
         // If the field is optional and there is no value present, skip check.
@@ -150,75 +153,39 @@ public class ReferenceTracker {
      * to confirm if it meets the conditions whereby the conditional field is required. If the conditional field is
      * required confirm that a value has been provided, if not, log an error.
      */
-    public Set<NewGTFSError> checkConditionallyRequiredFields(
-        Table table,
-        Field[] fields,
-        String[] rowData,
-        int lineNumber
-    ) {
+    public Set<NewGTFSError> checkConditionallyRequiredFields(LineContext lineContext) {
         Set<NewGTFSError> errors = new HashSet<>();
-        Map<Field, ConditionalRequirement[]> fieldsToCheck = table.getConditionalRequirements();
+        Map<Field, ConditionalRequirement[]> fieldsToCheck = lineContext.table.getConditionalRequirements();
 
         // Work through each field that has been assigned a conditional requirement.
         for (Map.Entry<Field, ConditionalRequirement[]> entry : fieldsToCheck.entrySet()) {
             Field referenceField = entry.getKey();
-            // Extract reference field value from the row currently being processed.
-            String referenceFieldValue =
-                getValueForRow(
-                    rowData,
-                    Field.getFieldIndex(fields, referenceField.name)
-                );
-            String entityId =
-                getValueForRow(
-                    rowData,
-                    table.getKeyFieldIndex(fields)
-                );
             ConditionalRequirement[] conditionalRequirements = entry.getValue();
-
             // Work through each field's conditional requirements.
             for (ConditionalRequirement check : conditionalRequirements) {
-                // Extract conditional field value from the row currently being processed.
-                String conditionalFieldValue =
-                    getValueForRow(
-                        rowData,
-                        Field.getFieldIndex(fields, check.conditionalFieldName)
-                    );
-                switch(check.referenceCheck) {
-                    case ROW_COUNT_GREATER_THAN_ONE:
+                switch(check.referenceFieldCheck) {
+                    case HAS_MULTIPLE_ROWS:
                         errors.addAll(
-                            ConditionalRequirement.checkRowCountGreaterThanOne(
-                                table,
-                                lineNumber,
-                                foreignFieldIds,
-                                check,
-                                conditionalFieldValue,
-                                entityId
-                            )
+                            ConditionalRequirement.checkHasMultipleRows(lineContext, uniqueValuesForFields, check)
+                        );
+                        break;
+                    case FIELD_NOT_EMPTY:
+                        errors.addAll(
+                            ConditionalRequirement.checkFieldEmpty(lineContext, referenceField, uniqueValuesForFields, check)
                         );
                         break;
                     case FIELD_IN_RANGE:
                         errors.addAll(
-                            ConditionalRequirement.checkFieldInRange(
-                                table,
-                                lineNumber,
-                                referenceField,
-                                check,
-                                referenceFieldValue,
-                                conditionalFieldValue,
-                                entityId
-                            )
+                            ConditionalRequirement.checkFieldInRange(lineContext, referenceField, check)
                         );
                         break;
-                    case FOREIGN_FIELD_VALUE_MATCH:
+                    case FOREIGN_REF_EXISTS:
                         errors.addAll(
-                            ConditionalRequirement.checkForeignFieldValueMatch(
-                                table,
-                                lineNumber,
+                            ConditionalRequirement.checkForeignRefExists(
+                                lineContext,
                                 referenceField,
                                 check,
-                                referenceFieldValue,
-                                foreignFieldIds,
-                                entityId
+                                uniqueValuesForFields
                             )
                         );
                         break;
@@ -226,14 +193,5 @@ public class ReferenceTracker {
             }
         }
         return errors;
-    }
-
-    /**
-     * Get value for a particular column index from a set of row data. Note: the row data here has one extra value at
-     * the beginning of the array that represents the line number (hence the +1). This is because the data is formatted
-     * for batch insertion into a postgres table.
-     */
-    private String getValueForRow(String[] rowData, int columnIndex) {
-        return rowData[columnIndex + 1];
     }
 }

--- a/src/main/java/com/conveyal/gtfs/loader/Table.java
+++ b/src/main/java/com/conveyal/gtfs/loader/Table.java
@@ -51,8 +51,8 @@ import static com.conveyal.gtfs.error.NewGTFSErrorType.DUPLICATE_HEADER;
 import static com.conveyal.gtfs.error.NewGTFSErrorType.TABLE_IN_SUBDIRECTORY;
 import static com.conveyal.gtfs.loader.ConditionalCheckType.FIELD_IN_RANGE;
 import static com.conveyal.gtfs.loader.ConditionalCheckType.FIELD_NOT_EMPTY;
-import static com.conveyal.gtfs.loader.ConditionalCheckType.FOREIGN_FIELD_VALUE_MATCH;
-import static com.conveyal.gtfs.loader.ConditionalCheckType.ROW_COUNT_GREATER_THAN_ONE;
+import static com.conveyal.gtfs.loader.ConditionalCheckType.FOREIGN_REF_EXISTS;
+import static com.conveyal.gtfs.loader.ConditionalCheckType.HAS_MULTIPLE_ROWS;
 import static com.conveyal.gtfs.loader.JdbcGtfsLoader.sanitize;
 import static com.conveyal.gtfs.loader.Requirement.EDITOR;
 import static com.conveyal.gtfs.loader.Requirement.EXTENSION;
@@ -105,8 +105,8 @@ public class Table {
         new StringField("agency_id",  OPTIONAL).requireConditions(
             // If there is more than one agency, the agency_id must be provided
             // https://developers.google.com/transit/gtfs/reference#agencytxt
-            new ConditionalRequirement("agency_id", ROW_COUNT_GREATER_THAN_ONE)
-        ).foreign(),
+            new ConditionalRequirement("agency_id", HAS_MULTIPLE_ROWS)
+        ).hasForeignReferences(),
         new StringField("agency_name", REQUIRED),
         new URLField("agency_url", REQUIRED),
         new StringField("agency_timezone", REQUIRED), // FIXME new field type for time zones?
@@ -158,7 +158,7 @@ public class Table {
         new StringField("agency_id", OPTIONAL).requireConditions(
             // If there is more than one agency, this agency_id is required.
             // https://developers.google.com/transit/gtfs/reference#fare_attributestxt
-            new ConditionalRequirement("agency_id", FIELD_NOT_EMPTY, ROW_COUNT_GREATER_THAN_ONE)
+            new ConditionalRequirement("agency_id", HAS_MULTIPLE_ROWS, FIELD_NOT_EMPTY)
         ),
         new IntegerField("transfer_duration", OPTIONAL)
     ).addPrimaryKey();
@@ -186,7 +186,7 @@ public class Table {
         new StringField("agency_id",  OPTIONAL).isReferenceTo(AGENCY).requireConditions(
             // If there is more than one agency, this agency_id is required.
             // https://developers.google.com/transit/gtfs/reference#routestxt
-            new ConditionalRequirement("agency_id", FIELD_NOT_EMPTY, ROW_COUNT_GREATER_THAN_ONE)
+            new ConditionalRequirement("agency_id", HAS_MULTIPLE_ROWS, FIELD_NOT_EMPTY)
         ),
         new StringField("route_short_name", OPTIONAL), // one of short or long must be provided
         new StringField("route_long_name", OPTIONAL),
@@ -240,7 +240,7 @@ public class Table {
         new StringField("stop_desc", OPTIONAL),
         new DoubleField("stop_lat", OPTIONAL, -80, 80, 6).requireConditions(),
         new DoubleField("stop_lon", OPTIONAL, -180, 180, 6).requireConditions(),
-        new StringField("zone_id", OPTIONAL).foreign(),
+        new StringField("zone_id", OPTIONAL).hasForeignReferences(),
         new URLField("stop_url", OPTIONAL),
         new ShortField("location_type", OPTIONAL, 4).requireConditions(
             // If the location type is defined and within range, the conditional fields are required.
@@ -261,19 +261,19 @@ public class Table {
         new StringField("fare_id", REQUIRED).isReferenceTo(FARE_ATTRIBUTES),
         new StringField("route_id", OPTIONAL).isReferenceTo(ROUTES),
         new StringField("origin_id", OPTIONAL).requireConditions(
-            // If the origin id is defined, the matching zone_id must be defined in stops.
+            // If the origin_id is defined, its value must exist as a zone_id in stops.txt.
             // https://developers.google.com/transit/gtfs/reference#fare_rulestxt
-            new ConditionalRequirement("zone_id", FOREIGN_FIELD_VALUE_MATCH)
+            new ConditionalRequirement("zone_id", FOREIGN_REF_EXISTS)
         ),
         new StringField("destination_id", OPTIONAL).requireConditions(
-            // If the destination id is defined, the matching zone_id must be defined in stops.
+            // If the destination_id is defined, its value must exist as a zone_id in stops.txt.
             // https://developers.google.com/transit/gtfs/reference#fare_rulestxt
-            new ConditionalRequirement("zone_id", FOREIGN_FIELD_VALUE_MATCH)
+            new ConditionalRequirement("zone_id", FOREIGN_REF_EXISTS)
         ),
         new StringField("contains_id", OPTIONAL).requireConditions(
-            // If the contains id is defined, the matching zone_id must be defined in stops.
+            // If the contains_id is defined, its value must exist as a zone_id in stops.txt.
             // https://developers.google.com/transit/gtfs/reference#fare_rulestxt
-            new ConditionalRequirement("zone_id", FOREIGN_FIELD_VALUE_MATCH)
+            new ConditionalRequirement("zone_id", FOREIGN_REF_EXISTS)
         )
     )
     .withParentTable(FARE_ATTRIBUTES)

--- a/src/test/java/com/conveyal/gtfs/loader/ConditionallyRequiredTest.java
+++ b/src/test/java/com/conveyal/gtfs/loader/ConditionallyRequiredTest.java
@@ -16,7 +16,7 @@ import java.util.stream.Stream;
 import static com.conveyal.gtfs.GTFS.load;
 import static com.conveyal.gtfs.GTFS.validate;
 import static com.conveyal.gtfs.TestUtils.assertThatSqlCountQueryYieldsExpectedCount;
-import static com.conveyal.gtfs.error.NewGTFSErrorType.AGENCY_ID_REQUIRED_FOR_TABLES_WITH_MORE_THAN_ONE_RECORD;
+import static com.conveyal.gtfs.error.NewGTFSErrorType.AGENCY_ID_REQUIRED_FOR_MULTI_AGENCY_FEEDS;
 import static com.conveyal.gtfs.error.NewGTFSErrorType.CONDITIONALLY_REQUIRED;
 
 public class ConditionallyRequiredTest {
@@ -94,12 +94,12 @@ public class ConditionallyRequiredTest {
 
     @Test
     public void routeTableMissingConditionallyRequiredAgencyId() {
-        checkFeedHasOneError(AGENCY_ID_REQUIRED_FOR_TABLES_WITH_MORE_THAN_ONE_RECORD, "Route","2", "21","agency_id is conditionally required when there is more than one agency.");
+        checkFeedHasOneError(AGENCY_ID_REQUIRED_FOR_MULTI_AGENCY_FEEDS, "Route","2", "21","agency_id is conditionally required when there is more than one agency.");
     }
 
     @Test
     public void fareAttributeTableMissingConditionallyRequiredAgencyId() {
-        checkFeedHasOneError(AGENCY_ID_REQUIRED_FOR_TABLES_WITH_MORE_THAN_ONE_RECORD, "FareAttribute","2", "1","agency_id is conditionally required when there is more than one agency.");
+        checkFeedHasOneError(AGENCY_ID_REQUIRED_FOR_MULTI_AGENCY_FEEDS, "FareAttribute","2", "1","agency_id is conditionally required when there is more than one agency.");
     }
 
     /**


### PR DESCRIPTION
Contains tweaks for #312. Namely:
- adds `LineContext` class to encapsulate some shared logic/clean things up
- renames some conditions/methods to be more concise/accurate (notably: conditionalField to dependentField)
- adds a new check method for `checkFieldEmpty`. I think the reference/dependent checks were mixed up, so as part of that I also reordered those (for routes#agency_id and fare_rules#agency_id)
- maybe a couple of other things... sorry if this went overboard!

FYI, some tests are broken. Happy to help resolve if help is needed!