### PR TITLE
Remove codecov reporting

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -48,10 +48,6 @@ jobs:
         key: maven-local-repo
     - name: Build with Maven
       run: mvn --no-transfer-progress package
-    - name: Codecov
-      # this first codecov run will upload a report associated with the commit set through CI environment variables
-      uses: codecov/codecov-action@v1.2.0
-      continue-on-error: true
     - name: Clear contents of the target directory
       # Avoids issues where maven-semantic-release attempts to upload
       # multiple versions/builds (and fails due to the pre-existence of the version on maven central).
@@ -71,7 +67,3 @@ jobs:
         GH_TOKEN: ${{ secrets.GH_TOKEN }}
       run: |
        semantic-release --prepare @conveyal/maven-semantic-release --publish @semantic-release/github,@conveyal/maven-semantic-release --verify-conditions @semantic-release/github,@conveyal/maven-semantic-release --verify-release @conveyal/maven-semantic-release --use-conveyal-workflow --dev-branch=dev --skip-maven-deploy
-       if [[ "$GITHUB_REF_SLUG" = "master" ]]; then
-         bash <(curl -s https://codecov.io/bash) -C "$(git rev-parse HEAD)"
-         bash <(curl -s https://codecov.io/bash) -C "$(git rev-parse HEAD^)"
-       fi


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Removes codecov reporting as we don't really use it anymore.