### PR TITLE
Add stop_times linked fields continuous_pickup, continuous_drop_off.

### DIFF
--- a/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
+++ b/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
@@ -634,6 +634,8 @@ public class JdbcTableWriter implements TableWriter {
                     "timepoint",
                     "drop_off_type",
                     "pickup_type",
+                    "continuous_pickup",
+                    "continuous_drop_off",
                     "shape_dist_traveled"
                 );
             }

--- a/src/test/java/com/conveyal/gtfs/loader/JDBCTableWriterTest.java
+++ b/src/test/java/com/conveyal/gtfs/loader/JDBCTableWriterTest.java
@@ -422,11 +422,11 @@ public class JDBCTableWriterTest {
     }
 
     /**
-     * This test verifies that stop_times#shape_dist_traveled (and other "linked fields") are updated when a pattern
+     * This test verifies that stop_times#shape_dist_traveled and other linked fields are updated when a pattern
      * is updated.
      */
     @Test
-    public void shouldUpdateStopTimeShapeDistTraveledOnPatternStopUpdate() throws IOException, SQLException, InvalidNamespaceException {
+    public void shouldUpdateStopTimeOnPatternStopUpdate() throws IOException, SQLException, InvalidNamespaceException {
         final String[] STOP_TIMES_LINKED_FIELDS = new String[] {
             "shape_dist_traveled",
             "timepoint",
@@ -481,10 +481,8 @@ public class JDBCTableWriterTest {
         ResultSet resultSet = statement.executeQuery();
         while (resultSet.next()) {
             // First stop_time shape_dist_traveled should be zero.
-            assertThat(resultSet.getInt(1), equalTo(0));
-
-            // Other linked fields should be interpreted as zero.
-            for (int i = 2; i <= STOP_TIMES_LINKED_FIELDS.length; i++) {
+            // Other linked fields should be interpreted as zero too.
+            for (int i = 1; i <= STOP_TIMES_LINKED_FIELDS.length; i++) {
                 assertThat(resultSet.getInt(i), equalTo(0));
             }
         }

--- a/src/test/java/com/conveyal/gtfs/loader/JDBCTableWriterTest.java
+++ b/src/test/java/com/conveyal/gtfs/loader/JDBCTableWriterTest.java
@@ -427,6 +427,14 @@ public class JDBCTableWriterTest {
      */
     @Test
     public void shouldUpdateStopTimeShapeDistTraveledOnPatternStopUpdate() throws IOException, SQLException, InvalidNamespaceException {
+        final String[] STOP_TIMES_LINKED_FIELDS = new String[] {
+            "shape_dist_traveled",
+            "timepoint",
+            "drop_off_type",
+            "pickup_type",
+            "continuous_pickup",
+            "continuous_drop_off"
+        };
         String routeId = newUUID();
         String patternId = newUUID();
         int startTime = 6 * 60 * 60; // 6 AM
@@ -459,10 +467,12 @@ public class JDBCTableWriterTest {
         assertNotNull(uuid);
         // Check that trip exists.
         assertThatSqlQueryYieldsRowCount(getColumnsForId(createdTrip.id, Table.TRIPS), 1);
-        // Check the stop_time's initial shape_dist_traveled value. TODO test that other linked fields are updated?
+
+        // Check the stop_time's initial shape_dist_traveled value and other linked fields.
         PreparedStatement statement = testDataSource.getConnection().prepareStatement(
             String.format(
-                "select shape_dist_traveled from %s.stop_times where stop_sequence=1 and trip_id='%s'",
+                "select %s from %s.stop_times where stop_sequence=1 and trip_id='%s'",
+                String.join(", ", STOP_TIMES_LINKED_FIELDS),
                 testNamespace,
                 createdTrip.trip_id
             )
@@ -472,10 +482,23 @@ public class JDBCTableWriterTest {
         while (resultSet.next()) {
             // First stop_time shape_dist_traveled should be zero.
             assertThat(resultSet.getInt(1), equalTo(0));
+
+            // Other linked fields should be interpreted as zero.
+            for (int i = 2; i <= STOP_TIMES_LINKED_FIELDS.length; i++) {
+                assertThat(resultSet.getInt(i), equalTo(0));
+            }
         }
+
         // Update pattern_stop#shape_dist_traveled and check that the stop_time's shape_dist value is updated.
         final double updatedShapeDistTraveled = 45.5;
-        pattern.pattern_stops[1].shape_dist_traveled = updatedShapeDistTraveled;
+        PatternStopDTO pattern_stop = pattern.pattern_stops[1];
+        pattern_stop.shape_dist_traveled = updatedShapeDistTraveled;
+        // Assign an arbitrary value (the order of appearance in STOP_TIMES_LINKED_FIELDS) for the other linked fields.
+        pattern_stop.timepoint = 2;
+        pattern_stop.drop_off_type = 3;
+        pattern_stop.pickup_type = 4;
+        pattern_stop.continuous_pickup = 5;
+        pattern_stop.continuous_drop_off = 6;
         JdbcTableWriter patternUpdater = createTestTableWriter(Table.PATTERNS);
         String updatedPatternOutput = patternUpdater.update(pattern.id, mapper.writeValueAsString(pattern), true);
         LOG.info("Updated pattern: {}", updatedPatternOutput);
@@ -483,6 +506,11 @@ public class JDBCTableWriterTest {
         while (resultSet2.next()) {
             // First stop_time shape_dist_traveled should be updated.
             assertThat(resultSet2.getDouble(1), equalTo(updatedShapeDistTraveled));
+
+            // Other linked fields should be as set above.
+            for (int i = 2; i <= STOP_TIMES_LINKED_FIELDS.length; i++) {
+                assertThat(resultSet2.getInt(i), equalTo(i));
+            }
         }
     }
 


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected => against existing PR _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [na] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [na] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [ ] All tests and CI builds passing

### Description

In this PR, `continuous_pickup` and `continuous_drop_off` linked fields in the `STOP_TIMES` table are set to be updated when a `PatternStop` entry is changed. This allows values in these fields to be exported to GTFS 2.0 archives in the Datatools GTFS editor.
