### PR TITLE
Make `continuous_pickup`/`drop_off` not required.

### DIFF
--- a/src/main/java/com/conveyal/gtfs/model/Route.java
+++ b/src/main/java/com/conveyal/gtfs/model/Route.java
@@ -103,13 +103,13 @@ public class Route extends Entity { // implements Entity.Factory<Route>
             r.route_long_name = getStringField("route_long_name", false);
             r.route_desc = getStringField("route_desc", false);
             r.route_type = getIntField("route_type", true, 0, 7);
-            r.route_sort_order = getIntField("route_type", false, 0, Integer.MAX_VALUE);
+            r.route_sort_order = getIntField("route_sort_order", false, 0, Integer.MAX_VALUE);
             r.route_url = getUrlField("route_url", false);
             r.route_color = getStringField("route_color", false);
             r.route_text_color = getStringField("route_text_color", false);
             r.route_branding_url = getUrlField("route_branding_url", false);
-            r.continuous_pickup = getIntField("continuous_pickup", true, 0, 3);
-            r.continuous_pickup = getIntField("continuous_drop_off", true, 0, 3);
+            r.continuous_pickup = getIntField("continuous_pickup", false, 0, 3, INT_MISSING);
+            r.continuous_drop_off = getIntField("continuous_drop_off", false, 0, 3, INT_MISSING);
             r.feed = feed;
             r.feed_id = feed.feedId;
             // Attempting to put a null key or value will cause an NPE in BTreeMap

--- a/src/main/java/com/conveyal/gtfs/model/StopTime.java
+++ b/src/main/java/com/conveyal/gtfs/model/StopTime.java
@@ -89,8 +89,8 @@ public class StopTime extends Entity implements Cloneable, Serializable {
             st.stop_headsign  = getStringField("stop_headsign", false);
             st.pickup_type    = getIntField("pickup_type", false, 0, 3); // TODO add ranges as parameters
             st.drop_off_type  = getIntField("drop_off_type", false, 0, 3);
-            st.continuous_pickup = getIntField("continuous_pickup", true, 0, 3);
-            st.continuous_drop_off = getIntField("continuous_drop_off", true, 0, 3);
+            st.continuous_pickup = getIntField("continuous_pickup", false, 0, 3, INT_MISSING);
+            st.continuous_drop_off = getIntField("continuous_drop_off", false, 0, 3, INT_MISSING);
             st.shape_dist_traveled = getDoubleField("shape_dist_traveled", false, 0D, Double.MAX_VALUE); // FIXME using both 0 and NaN for "missing", define DOUBLE_MISSING
             st.timepoint      = getIntField("timepoint", false, 0, 1, INT_MISSING);
             st.feed           = null; // this could circular-serialize the whole feed


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [na] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR is a partial fix for https://github.com/ibi-group/datatools-server/issues/434 and sets the `continuous_pickup` and `continuous_drop_off` fields in tables `stop_times` and `routes` to be optional per GTFS 2.0 spec. The PR also fixes an incorrect field load in table `routes`.
