### PR TITLE
Refactor location shapes to be saved with parent table Locations

### DIFF
--- a/src/main/java/com/conveyal/gtfs/graphql/GraphQLGtfsSchema.java
+++ b/src/main/java/com/conveyal/gtfs/graphql/GraphQLGtfsSchema.java
@@ -227,6 +227,7 @@ public class GraphQLGtfsSchema {
             .field(MapFetcher.field("stop_desc"))
             .field(MapFetcher.field("zone_id"))
             .field(MapFetcher.field("stop_url"))
+            .field(MapFetcher.field("geometry_type"))
             .field(newFieldDefinition()
                     .name("location_shapes")
                     .type(new GraphQLList(locationShapeType))

--- a/src/main/java/com/conveyal/gtfs/loader/EntityPopulator.java
+++ b/src/main/java/com/conveyal/gtfs/loader/EntityPopulator.java
@@ -241,6 +241,7 @@ public interface EntityPopulator<T> {
         location.stop_name = getStringIfPresent(result, "location_stop_name", columnForName);
         location.zone_id = getStringIfPresent(result, "zone_id", columnForName);
         location.stop_url = getUrlIfPresent(result, "location_stop_url", columnForName);
+        location.geometry_type = getStringIfPresent(result, "geometry_type", columnForName);
         return location;
     };
 
@@ -264,7 +265,6 @@ public interface EntityPopulator<T> {
         LocationShape locationShape = new LocationShape();
         locationShape.location_id = getStringIfPresent(result, "location_id", columnForName);
         locationShape.geometry_id = getStringIfPresent(result, "polygon_id", columnForName);
-        locationShape.geometry_type = getStringIfPresent(result, "geometry_type", columnForName);
 
 //        locationShape.shape_id = getStringIfPresent(result, "shape_id", columnForName);
 //        locationShape.shape_polygon_id = getIntIfPresent(result, "shape_polygon_id", columnForName);

--- a/src/main/java/com/conveyal/gtfs/loader/EntityPopulator.java
+++ b/src/main/java/com/conveyal/gtfs/loader/EntityPopulator.java
@@ -1,22 +1,6 @@
 package com.conveyal.gtfs.loader;
 
-import com.conveyal.gtfs.model.Agency;
-import com.conveyal.gtfs.model.BookingRule;
-import com.conveyal.gtfs.model.Calendar;
-import com.conveyal.gtfs.model.CalendarDate;
-import com.conveyal.gtfs.model.Entity;
-import com.conveyal.gtfs.model.FareAttribute;
-import com.conveyal.gtfs.model.Frequency;
-import com.conveyal.gtfs.model.LocationGroup;
-import com.conveyal.gtfs.model.LocationMetaData;
-import com.conveyal.gtfs.model.LocationShape;
-import com.conveyal.gtfs.model.PatternStop;
-import com.conveyal.gtfs.model.Route;
-import com.conveyal.gtfs.model.ScheduleException;
-import com.conveyal.gtfs.model.ShapePoint;
-import com.conveyal.gtfs.model.Stop;
-import com.conveyal.gtfs.model.StopTime;
-import com.conveyal.gtfs.model.Trip;
+import com.conveyal.gtfs.model.*;
 import gnu.trove.map.TObjectIntMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -251,6 +235,15 @@ public interface EntityPopulator<T> {
         return bookingRule;
     };
 
+    EntityPopulator<Location> LOCATION = (result, columnForName) -> {
+        Location location = new Location();
+        location.location_id = getStringIfPresent(result, "location_id", columnForName);
+        location.stop_name = getStringIfPresent(result, "location_stop_name", columnForName);
+        location.zone_id = getStringIfPresent(result, "zone_id", columnForName);
+        location.stop_url = getUrlIfPresent(result, "location_stop_url", columnForName);
+        return location;
+    };
+
     EntityPopulator<LocationGroup> LOCATION_GROUP = (result, columnForName) -> {
         LocationGroup locationGroup = new LocationGroup();
         locationGroup.location_group_id = getStringIfPresent(result, "location_group_id", columnForName);
@@ -269,14 +262,18 @@ public interface EntityPopulator<T> {
 
     EntityPopulator<LocationShape> LOCATION_SHAPES = (result, columnForName) -> {
         LocationShape locationShape = new LocationShape();
-        locationShape.shape_id = getStringIfPresent(result, "shape_id", columnForName);
-        locationShape.shape_polygon_id = getIntIfPresent(result, "shape_polygon_id", columnForName);
-        locationShape.shape_ring_id = getIntIfPresent(result, "shape_ring_id", columnForName);
-        locationShape.shape_line_string_id = getIntIfPresent(result, "shape_line_string_id", columnForName);
-        locationShape.shape_pt_lat = getDoubleIfPresent(result, "shape_pt_lat", columnForName);
-        locationShape.shape_pt_lon = getDoubleIfPresent(result, "shape_pt_lon", columnForName);
-        locationShape.shape_pt_sequence = getIntIfPresent(result, "shape_pt_sequence", columnForName);
-        locationShape.location_meta_data_id = getStringIfPresent(result, "location_meta_data_id", columnForName);
+        locationShape.location_id = getStringIfPresent(result, "location_id", columnForName);
+        locationShape.geometry_id = getStringIfPresent(result, "polygon_id", columnForName);
+        locationShape.geometry_type = getStringIfPresent(result, "geometry_type", columnForName);
+
+//        locationShape.shape_id = getStringIfPresent(result, "shape_id", columnForName);
+//        locationShape.shape_polygon_id = getIntIfPresent(result, "shape_polygon_id", columnForName);
+//        locationShape.shape_ring_id = getIntIfPresent(result, "shape_ring_id", columnForName);
+//        locationShape.shape_line_string_id = getIntIfPresent(result, "shape_line_string_id", columnForName);
+//        locationShape.shape_pt_lat = getDoubleIfPresent(result, "shape_pt_lat", columnForName);
+//        locationShape.shape_pt_lon = getDoubleIfPresent(result, "shape_pt_lon", columnForName);
+//        locationShape.shape_pt_sequence = getIntIfPresent(result, "shape_pt_sequence", columnForName);
+//        locationShape.location_meta_data_id = getStringIfPresent(result, "location_meta_data_id", columnForName);
         return locationShape;
     };
 

--- a/src/main/java/com/conveyal/gtfs/loader/Feed.java
+++ b/src/main/java/com/conveyal/gtfs/loader/Feed.java
@@ -36,6 +36,7 @@ public class Feed {
     public final TableReader<CalendarDate>  calendarDates;
     public final TableReader<FareAttribute> fareAttributes;
     public final TableReader<Frequency>     frequencies;
+    public final TableReader<Location>      locations;
     public final TableReader<LocationGroup> locationGroups;
     public final TableReader<LocationMetaData> locationMetaData;
     public final TableReader<LocationShape> locationShapes;
@@ -56,6 +57,7 @@ public class Feed {
         this.tablePrefix = tablePrefix == null ? "" : tablePrefix;
         agencies = new JDBCTableReader(Table.AGENCY, dataSource, tablePrefix, EntityPopulator.AGENCY);
         bookingRules = new JDBCTableReader(Table.BOOKING_RULES, dataSource, tablePrefix, EntityPopulator.BOOKING_RULE);
+        locations = new JDBCTableReader(Table.LOCATIONS, dataSource, tablePrefix, EntityPopulator.LOCATION);
         fareAttributes = new JDBCTableReader(Table.FARE_ATTRIBUTES, dataSource, tablePrefix, EntityPopulator.FARE_ATTRIBUTE);
         frequencies = new JDBCTableReader(Table.FREQUENCIES, dataSource, tablePrefix, EntityPopulator.FREQUENCY);
         locationGroups = new JDBCTableReader(Table.LOCATION_GROUPS, dataSource, tablePrefix, EntityPopulator.LOCATION_GROUP);

--- a/src/main/java/com/conveyal/gtfs/loader/FeedLoadResult.java
+++ b/src/main/java/com/conveyal/gtfs/loader/FeedLoadResult.java
@@ -29,6 +29,7 @@ public class FeedLoadResult implements Serializable {
     public TableLoadResult fareRules;
     public TableLoadResult feedInfo;
     public TableLoadResult frequencies;
+    public TableLoadResult locations;
     public TableLoadResult locationGroups;
     public TableLoadResult locationMetaData;
     public TableLoadResult locationShapes;
@@ -60,6 +61,7 @@ public class FeedLoadResult implements Serializable {
         fareRules = new TableLoadResult();
         feedInfo = new TableLoadResult();
         frequencies = new TableLoadResult();
+        locations = new TableLoadResult();
         locationGroups = new TableLoadResult();
         locationMetaData = new TableLoadResult();
         locationShapes = new TableLoadResult();

--- a/src/main/java/com/conveyal/gtfs/loader/JdbcGTFSFeedConverter.java
+++ b/src/main/java/com/conveyal/gtfs/loader/JdbcGTFSFeedConverter.java
@@ -108,6 +108,7 @@ public class JdbcGTFSFeedConverter {
             // Copy all tables (except for PATTERN_STOPS, which does not exist in GTFSFeed).
             copyEntityToSql(gtfsFeed.agency.values(), Table.AGENCY);
             copyEntityToSql(gtfsFeed.bookingRules.values(), Table.BOOKING_RULES);
+            copyEntityToSql(gtfsFeed.locations.values(), Table.LOCATIONS);
             copyEntityToSql(calendars, Table.CALENDAR);
             copyEntityToSql(calendarDates, Table.CALENDAR_DATES);
             copyEntityToSql(gtfsFeed.routes.values(), Table.ROUTES);

--- a/src/main/java/com/conveyal/gtfs/loader/JdbcGtfsExporter.java
+++ b/src/main/java/com/conveyal/gtfs/loader/JdbcGtfsExporter.java
@@ -8,7 +8,7 @@ import com.conveyal.gtfs.model.LocationShape;
 import com.conveyal.gtfs.model.ScheduleException;
 import com.conveyal.gtfs.model.Service;
 import com.conveyal.gtfs.util.GeoJsonException;
-import com.conveyal.gtfs.util.GeoJsonUtil;
+//import com.conveyal.gtfs.util.GeoJsonUtil;
 import com.google.common.collect.Lists;
 import org.apache.commons.dbutils.DbUtils;
 import org.postgresql.copy.CopyManager;
@@ -92,6 +92,7 @@ public class JdbcGtfsExporter {
             result.agency = export(Table.AGENCY, connection);
             // TODO: No idea if booking rules and location groups need to have a 'fromEditor' option?
             result.bookingRules = export(Table.BOOKING_RULES, connection);
+            result.locations = export(Table.LOCATIONS, connection);
             result.locationGroups = export(Table.LOCATION_GROUPS, connection);
             if (fromEditor) {
                 // only export calendar entries that have at least one day of service set
@@ -465,7 +466,7 @@ public class JdbcGtfsExporter {
         zipOutputStream.putNextEntry(new ZipEntry(Table.locationGeoJsonFileName));
         // Create and use PrintWriter, but don't close. This is done when the zip entry is closed.
         PrintWriter p = new PrintWriter(zipOutputStream);
-        p.println(GeoJsonUtil.packLocations(locationMetaData, locationShapes));
+//        p.println(GeoJsonUtil.packLocations(locationMetaData, locationShapes));
         p.flush();
         zipOutputStream.closeEntry();
     }

--- a/src/main/java/com/conveyal/gtfs/loader/JdbcGtfsLoader.java
+++ b/src/main/java/com/conveyal/gtfs/loader/JdbcGtfsLoader.java
@@ -168,6 +168,7 @@ public class JdbcGtfsLoader {
             result.translations = load(Table.TRANSLATIONS);
             result.attributions = load(Table.ATTRIBUTIONS);
             result.bookingRules = load(Table.BOOKING_RULES);
+            result.locations = load(Table.LOCATIONS);
             result.locationGroups = load(Table.LOCATION_GROUPS);
             result.locationMetaData = load(Table.LOCATION_META_DATA);
             result.locationShapes = load(Table.LOCATION_SHAPES);

--- a/src/main/java/com/conveyal/gtfs/loader/JdbcGtfsSnapshotter.java
+++ b/src/main/java/com/conveyal/gtfs/loader/JdbcGtfsSnapshotter.java
@@ -99,6 +99,7 @@ public class JdbcGtfsSnapshotter {
             result.fareRules = copy(Table.FARE_RULES, true);
             result.feedInfo = copy(Table.FEED_INFO, true);
             result.frequencies = copy(Table.FREQUENCIES, true);
+            result.locations = copy(Table.LOCATIONS, true);
             result.locationGroups = copy(Table.LOCATION_GROUPS, true);
             result.locationMetaData = copy(Table.LOCATION_META_DATA, true);
             result.locationShapes = copy(Table.LOCATION_SHAPES, true);

--- a/src/main/java/com/conveyal/gtfs/loader/Table.java
+++ b/src/main/java/com/conveyal/gtfs/loader/Table.java
@@ -19,6 +19,7 @@ import com.conveyal.gtfs.model.FareAttribute;
 import com.conveyal.gtfs.model.FareRule;
 import com.conveyal.gtfs.model.FeedInfo;
 import com.conveyal.gtfs.model.Frequency;
+import com.conveyal.gtfs.model.Location;
 import com.conveyal.gtfs.model.LocationGroup;
 import com.conveyal.gtfs.model.LocationMetaData;
 import com.conveyal.gtfs.model.LocationShape;
@@ -34,7 +35,7 @@ import com.conveyal.gtfs.model.Translation;
 import com.conveyal.gtfs.model.Trip;
 import com.conveyal.gtfs.storage.StorageException;
 import com.conveyal.gtfs.util.GeoJsonException;
-import com.conveyal.gtfs.util.GeoJsonUtil;
+//import com.conveyal.gtfs.util.GeoJsonUtil;
 import com.csvreader.CsvReader;
 import org.apache.commons.io.input.BOMInputStream;
 import org.slf4j.Logger;
@@ -444,6 +445,14 @@ public class Table {
             new URLField("booking_url", OPTIONAL)
     );
 
+    public static final Table LOCATIONS = new Table("locations", Location.class, OPTIONAL,
+            new StringField("location_id", REQUIRED),
+            new StringField("stop_name", OPTIONAL),
+            new StringField("stop_desc", OPTIONAL),
+            new StringField("zone_id", OPTIONAL),
+            new URLField("stop_url", OPTIONAL)
+    );
+
     // https://github.com/MobilityData/gtfs-flex/blob/master/spec/reference.md#location_groupstxt-file-added
     public static final Table LOCATION_GROUPS = new Table("location_groups", LocationGroup.class, OPTIONAL,
             new StringField("location_group_id", REQUIRED),
@@ -463,15 +472,21 @@ public class Table {
 
     // https://github.com/MobilityData/gtfs-flex/blob/master/spec/reference.md#locationsgeojson-file-added
     public static final Table LOCATION_SHAPES = new Table("location_shapes", LocationShape.class, OPTIONAL,
-        new StringField("shape_id", REQUIRED),
-        new IntegerField("shape_polygon_id", REQUIRED, -1, Integer.MAX_VALUE),
-        new IntegerField("shape_ring_id", REQUIRED, -1, Integer.MAX_VALUE),
-        new IntegerField("shape_line_string_id", REQUIRED,  -1, Integer.MAX_VALUE),
-        new DoubleField("shape_pt_lat", REQUIRED, -80, 80, 6),
-        new DoubleField("shape_pt_lon", REQUIRED, -180, 180, 6),
-        new IntegerField("shape_pt_sequence", REQUIRED),
-        new StringField("location_meta_data_id", REQUIRED).isReferenceTo(LOCATION_META_DATA)
-    );
+//        new StringField("shape_id", REQUIRED),
+        new StringField("location_id", REQUIRED).isReferenceTo(LOCATIONS),
+        new StringField("geometry_id", REQUIRED),
+        new StringField("geometry_type", REQUIRED),
+        new DoubleField("geometry_pt_lat", REQUIRED, -80, 80, 6),
+        new DoubleField("geometry_pt_lon", REQUIRED, -180, 180, 6)
+
+//        new IntegerField("shape_polygon_id", REQUIRED, -1, Integer.MAX_VALUE),
+//        new IntegerField("shape_ring_id", REQUIRED, -1, Integer.MAX_VALUE),
+//        new IntegerField("shape_line_string_id", REQUIRED,  -1, Integer.MAX_VALUE),
+//        new DoubleField("shape_pt_lat", REQUIRED, -80, 80, 6),
+//        new DoubleField("shape_pt_lon", REQUIRED, -180, 180, 6)
+//        new IntegerField("shape_pt_sequence", REQUIRED)
+//        new StringField("location_meta_data_id", REQUIRED).isReferenceTo(LOCATION_META_DATA),
+    ).withParentTable(LOCATIONS);
 
     /** List of tables in order needed for checking referential integrity during load stage. */
     public static final Table[] tablesInOrder = {
@@ -496,7 +511,8 @@ public class Table {
         BOOKING_RULES,
         LOCATION_GROUPS,
         LOCATION_META_DATA,
-        LOCATION_SHAPES
+        LOCATION_SHAPES,
+        LOCATIONS,
     };
 
     /**
@@ -714,15 +730,15 @@ public class Table {
         ZipEntry entry
     ) throws IOException, GeoJsonException {
         CsvReader csvReader;
-        if (tableFileName.equals(locationGeoJsonFileName)) {
-            csvReader = GeoJsonUtil.getCsvReaderFromGeoJson(name, zipFile, entry);
-        } else {
+//        if (tableFileName.equals(locationGeoJsonFileName)) {
+////            csvReader = GeoJsonUtil.getCsvReaderFromGeoJson(name, zipFile, entry);
+//        } else {
             InputStream zipInputStream = zipFile.getInputStream(entry);
             // Skip any byte order mark that may be present. Files must be UTF-8,
             // but the GTFS spec says that "files that include the UTF byte order mark are acceptable".
             InputStream bomInputStream = new BOMInputStream(zipInputStream);
             csvReader = new CsvReader(bomInputStream, ',', StandardCharsets.UTF_8);
-        }
+//        }
         return csvReader;
     }
 

--- a/src/main/java/com/conveyal/gtfs/loader/Table.java
+++ b/src/main/java/com/conveyal/gtfs/loader/Table.java
@@ -450,7 +450,8 @@ public class Table {
             new StringField("stop_name", OPTIONAL),
             new StringField("stop_desc", OPTIONAL),
             new StringField("zone_id", OPTIONAL),
-            new URLField("stop_url", OPTIONAL)
+            new URLField("stop_url", OPTIONAL),
+            new StringField("geometry_type", REQUIRED)
     );
 
     // https://github.com/MobilityData/gtfs-flex/blob/master/spec/reference.md#location_groupstxt-file-added
@@ -472,20 +473,10 @@ public class Table {
 
     // https://github.com/MobilityData/gtfs-flex/blob/master/spec/reference.md#locationsgeojson-file-added
     public static final Table LOCATION_SHAPES = new Table("location_shapes", LocationShape.class, OPTIONAL,
-//        new StringField("shape_id", REQUIRED),
         new StringField("location_id", REQUIRED).isReferenceTo(LOCATIONS),
         new StringField("geometry_id", REQUIRED),
-        new StringField("geometry_type", REQUIRED),
         new DoubleField("geometry_pt_lat", REQUIRED, -80, 80, 6),
         new DoubleField("geometry_pt_lon", REQUIRED, -180, 180, 6)
-
-//        new IntegerField("shape_polygon_id", REQUIRED, -1, Integer.MAX_VALUE),
-//        new IntegerField("shape_ring_id", REQUIRED, -1, Integer.MAX_VALUE),
-//        new IntegerField("shape_line_string_id", REQUIRED,  -1, Integer.MAX_VALUE),
-//        new DoubleField("shape_pt_lat", REQUIRED, -80, 80, 6),
-//        new DoubleField("shape_pt_lon", REQUIRED, -180, 180, 6)
-//        new IntegerField("shape_pt_sequence", REQUIRED)
-//        new StringField("location_meta_data_id", REQUIRED).isReferenceTo(LOCATION_META_DATA),
     ).withParentTable(LOCATIONS);
 
     /** List of tables in order needed for checking referential integrity during load stage. */

--- a/src/main/java/com/conveyal/gtfs/model/Entity.java
+++ b/src/main/java/com/conveyal/gtfs/model/Entity.java
@@ -18,7 +18,7 @@ import com.conveyal.gtfs.loader.DateField;
 import com.conveyal.gtfs.loader.Table;
 import com.conveyal.gtfs.util.Deduplicator;
 import com.conveyal.gtfs.util.GeoJsonException;
-import com.conveyal.gtfs.util.GeoJsonUtil;
+//import com.conveyal.gtfs.util.GeoJsonUtil;
 import com.csvreader.CsvReader;
 import com.csvreader.CsvWriter;
 

--- a/src/main/java/com/conveyal/gtfs/model/Location.java
+++ b/src/main/java/com/conveyal/gtfs/model/Location.java
@@ -18,6 +18,7 @@ public class Location extends Entity {
     public String stop_desc;
     public String zone_id;
     public URL stop_url;
+    public String geometry_type;
 
     @Override
     public String getId() {
@@ -37,6 +38,7 @@ public class Location extends Entity {
         statement.setString(oneBasedIndex++, stop_desc);
         statement.setString(oneBasedIndex++, zone_id);
         statement.setString(oneBasedIndex++, stop_url != null ? stop_url.toString() : null);
+        statement.setString(oneBasedIndex++, geometry_type);
     }
 
     public static class Loader extends Entity.Loader<Location> {
@@ -58,6 +60,8 @@ public class Location extends Entity {
             location.stop_name = getStringField("stop_name", false);
             location.zone_id = getStringField("zone_id", false);
             location.stop_url = getUrlField("stop_url", false);
+            // Must be a geometry associated w/ a location
+            location.geometry_type = getStringField("geometry_type", true);
 
             // Attempting to put a null key or value will cause an NPE in BTreeMap
             if (location.location_id != null) {
@@ -79,7 +83,7 @@ public class Location extends Entity {
 
         @Override
         public void writeHeaders() throws IOException {
-            writer.writeRecord(new String[]{"location_id", "stop_name", "zone_id", "stop_url"});
+            writer.writeRecord(new String[]{"location_id", "stop_name", "zone_id", "stop_url", "geometry_type"});
         }
 
         @Override
@@ -88,6 +92,7 @@ public class Location extends Entity {
             writeStringField(locations.zone_id);
             writeStringField(locations.stop_name);
             writeUrlField(locations.stop_url);
+            writeStringField(locations.geometry_type);
             endRecord();
         }
 
@@ -105,7 +110,8 @@ public class Location extends Entity {
         return stop_name == that.stop_name &&
                 zone_id == that.zone_id &&
                 Objects.equals(stop_url, that.stop_url) &&
-                Objects.equals(location_id, that.location_id);
+                Objects.equals(location_id, that.location_id) &&
+                geometry_type == that.geometry_type;
     }
 
     @Override
@@ -114,7 +120,8 @@ public class Location extends Entity {
                 location_id,
                 stop_name,
                 stop_url,
-                zone_id
+                zone_id,
+                geometry_type
         );
     }
 }

--- a/src/main/java/com/conveyal/gtfs/model/Location.java
+++ b/src/main/java/com/conveyal/gtfs/model/Location.java
@@ -1,0 +1,120 @@
+package com.conveyal.gtfs.model;
+
+import com.conveyal.gtfs.GTFSFeed;
+
+import java.io.IOException;
+import java.net.URL;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Iterator;
+import java.util.Objects;
+
+public class Location extends Entity {
+
+    private static final long serialVersionUID = -3961639608144161095L;
+
+    public String location_id;
+    public String stop_name;
+    public String stop_desc;
+    public String zone_id;
+    public URL stop_url;
+
+    @Override
+    public String getId() {
+        return location_id;
+    }
+
+    /**
+     * Sets the parameters for a prepared statement following the parameter order defined in
+     * {@link com.conveyal.gtfs.loader.Table#LOCATIONS}. JDBC prepared statement parameters use a one-based index.
+     */
+    @Override
+    public void setStatementParameters(PreparedStatement statement, boolean setDefaultId) throws SQLException {
+        int oneBasedIndex = 1;
+        if (!setDefaultId) statement.setInt(oneBasedIndex++, id);
+        statement.setString(oneBasedIndex++, location_id);
+        statement.setString(oneBasedIndex++, stop_name);
+        statement.setString(oneBasedIndex++, stop_desc);
+        statement.setString(oneBasedIndex++, zone_id);
+        statement.setString(oneBasedIndex++, stop_url != null ? stop_url.toString() : null);
+    }
+
+    public static class Loader extends Entity.Loader<Location> {
+
+        public Loader(GTFSFeed feed) {
+            super(feed, "locations");
+        }
+
+        @Override
+        protected boolean isRequired() {
+            return false;
+        }
+
+        @Override
+        public void loadOneRow() throws IOException {
+            Location location = new Location();
+
+            location.id = row + 1;
+            location.stop_name = getStringField("stop_name", false);
+            location.zone_id = getStringField("zone_id", false);
+            location.stop_url = getUrlField("stop_url", false);
+
+            // Attempting to put a null key or value will cause an NPE in BTreeMap
+            if (location.location_id != null) {
+                feed.locations.put(location.location_id, location);
+            }
+
+            /*
+              Check referential integrity without storing references. Location cannot directly reference Calenders
+              because they would be serialized into the MapDB.
+             */
+//            getRefField("location_id", true, feed.);
+        }
+    }
+
+    public static class Writer extends Entity.Writer<Location> {
+        public Writer(GTFSFeed feed) {
+            super(feed, "locations");
+        }
+
+        @Override
+        public void writeHeaders() throws IOException {
+            writer.writeRecord(new String[]{"location_id", "stop_name", "zone_id", "stop_url"});
+        }
+
+        @Override
+        public void writeOneRow(Location locations) throws IOException {
+            writeStringField(locations.location_id);
+            writeStringField(locations.zone_id);
+            writeStringField(locations.stop_name);
+            writeUrlField(locations.stop_url);
+            endRecord();
+        }
+
+        @Override
+        public Iterator<Location> iterator() {
+            return this.feed.locations.values().iterator();
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Location that = (Location) o;
+        return stop_name == that.stop_name &&
+                zone_id == that.zone_id &&
+                Objects.equals(stop_url, that.stop_url) &&
+                Objects.equals(location_id, that.location_id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                location_id,
+                stop_name,
+                stop_url,
+                zone_id
+        );
+    }
+}

--- a/src/main/java/com/conveyal/gtfs/model/LocationShape.java
+++ b/src/main/java/com/conveyal/gtfs/model/LocationShape.java
@@ -20,7 +20,6 @@ public class LocationShape extends Entity{
 
     public String location_id;
     public String geometry_id;
-    public String geometry_type;
     public double geometry_pt_lat;
     public double geometry_pt_lon;
 
@@ -36,7 +35,6 @@ public class LocationShape extends Entity{
         if (!setDefaultId) statement.setInt(oneBasedIndex++, id);
         statement.setString(oneBasedIndex++, location_id);
         statement.setString(oneBasedIndex++, geometry_id);
-        statement.setString(oneBasedIndex++, geometry_type);
         statement.setDouble(oneBasedIndex++, geometry_pt_lat);
         statement.setDouble(oneBasedIndex++, geometry_pt_lon);
     }

--- a/src/main/java/com/conveyal/gtfs/model/LocationShape.java
+++ b/src/main/java/com/conveyal/gtfs/model/LocationShape.java
@@ -1,153 +1,180 @@
 package com.conveyal.gtfs.model;
 
 import com.conveyal.gtfs.GTFSFeed;
+import com.conveyal.gtfs.util.Util;
+import org.locationtech.jts.geom.Coordinate;
+import org.mapdb.Fun;
 
 import java.io.IOException;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Objects;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
-public class LocationShape extends Entity {
+public class LocationShape extends Entity{
 
     private static final long serialVersionUID = -972419107947161195L;
 
-    public String shape_id;
-    public int shape_polygon_id = INT_MISSING;
-    public int shape_ring_id = INT_MISSING;
-    public int shape_line_string_id = INT_MISSING;
-    public double shape_pt_lat = DOUBLE_MISSING;
-    public double shape_pt_lon = DOUBLE_MISSING;
-    public int shape_pt_sequence = INT_MISSING;
-    public String location_meta_data_id;
+    public String location_id;
+    public String geometry_id;
+    public String geometry_type;
+    public double geometry_pt_lat;
+    public double geometry_pt_lon;
 
-    @Override
-    public String getId() {
-        return shape_id;
-    }
-
-    public int getShape_polygon_id() {
-        return shape_polygon_id;
-    }
-
-    public int getShape_ring_id() {
-        return shape_ring_id;
-    }
-
-    public int getShape_pt_sequence() {
-        return shape_pt_sequence;
-    }
-
-    public int getShape_line_string_id() {
-        return shape_line_string_id;
-    }
+    public LocationShape () {}
 
     /**
      * Sets the parameters for a prepared statement following the parameter order defined in
-     * {@link com.conveyal.gtfs.loader.Table#LOCATION_SHAPES}. JDBC prepared statement parameters use a one-based index.
+     * {@link com.conveyal.gtfs.loader.Table#PATTERN_STOP}. JDBC prepared statement parameters use a one-based index.
      */
     @Override
     public void setStatementParameters(PreparedStatement statement, boolean setDefaultId) throws SQLException {
         int oneBasedIndex = 1;
         if (!setDefaultId) statement.setInt(oneBasedIndex++, id);
-        statement.setString(oneBasedIndex++, shape_id);
-        setIntParameter(statement, oneBasedIndex++, shape_polygon_id);
-        setIntParameter(statement, oneBasedIndex++, shape_ring_id);
-        setIntParameter(statement, oneBasedIndex++, shape_line_string_id);
-        setDoubleParameter(statement, oneBasedIndex++, shape_pt_lat);
-        setDoubleParameter(statement, oneBasedIndex++, shape_pt_lon);
-        setIntParameter(statement, oneBasedIndex++, shape_pt_sequence);
-        statement.setString(oneBasedIndex, location_meta_data_id);
+        statement.setString(oneBasedIndex++, location_id);
+        statement.setString(oneBasedIndex++, geometry_id);
+        statement.setString(oneBasedIndex++, geometry_type);
+        statement.setDouble(oneBasedIndex++, geometry_pt_lat);
+        statement.setDouble(oneBasedIndex++, geometry_pt_lon);
     }
 
-    public static class Loader extends Entity.Loader<LocationShape> {
-
-        public Loader(GTFSFeed feed) {
-            super(feed, "location_shapes");
-        }
-
-        @Override
-        protected boolean isRequired() {
-            return false;
-        }
-
-        @Override
-        public void loadOneRow() throws IOException {
-            LocationShape locationShape = new LocationShape();
-            locationShape.id = row + 1; // offset line number by 1 to account for 0-based row index
-            locationShape.shape_id = getStringField("shape_id", true);
-            locationShape.shape_polygon_id = getIntField("shape_polygon_id", true, 0, Integer.MAX_VALUE);
-            locationShape.shape_ring_id = getIntField("shape_ring_id", true, 0, Integer.MAX_VALUE);
-            locationShape.shape_line_string_id = getIntField("shape_line_string_id", true, 0, Integer.MAX_VALUE);
-            locationShape.shape_pt_lat = getDoubleField("shape_pt_lat", true, 0D, Double.MAX_VALUE);
-            locationShape.shape_pt_lon = getDoubleField("shape_pt_lon", true, 0D, Double.MAX_VALUE);
-            locationShape.shape_pt_sequence = getIntField("shape_pt_sequence", true, 0, Integer.MAX_VALUE);
-            locationShape.location_meta_data_id = getStringField("location_meta_data_id", true);
-
-            // Attempting to put a null key or value will cause an NPE in BTreeMap
-            if (locationShape.shape_id != null) {
-                feed.locationShapes.put(locationShape.shape_id, locationShape);
-            }
-        }
-    }
-
-    /**
-     * Required by {@link com.conveyal.gtfs.util.GeoJsonUtil#getCsvReaderFromGeoJson(String, ZipFile, ZipEntry)} as part
-     * of the unpacking of GeoJson data to CSV.
-     */
-    public static String header() {
-        return "shape_id,shape_polygon_id,shape_ring_id,shape_line_string_id,shape_pt_lat,shape_pt_lon,shape_pt_sequence,location_meta_data_id\n";
-    }
-
-    /**
-     * Required by {@link com.conveyal.gtfs.util.GeoJsonUtil#getCsvReaderFromGeoJson(String, ZipFile, ZipEntry)} as part
-     * of the unpacking of GeoJson data to CSV.
-     */
-    public String toCsvRow() {
-        return shape_id + "," +
-            shape_polygon_id + "," +
-            shape_ring_id + "," +
-            shape_line_string_id + "," +
-            shape_pt_lat + "," +
-            shape_pt_lon + "," +
-            shape_pt_sequence + "," +
-            location_meta_data_id + "\n";
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        LocationShape that = (LocationShape) o;
-        return shape_polygon_id == that.shape_polygon_id &&
-            shape_ring_id == that.shape_ring_id &&
-            shape_line_string_id == that.shape_line_string_id &&
-            Double.compare(that.shape_pt_lat, shape_pt_lat) == 0 &&
-            Double.compare(that.shape_pt_lon, shape_pt_lon) == 0 &&
-            shape_pt_sequence == that.shape_pt_sequence &&
-            Objects.equals(shape_id, that.shape_id) &&
-            Objects.equals(location_meta_data_id, that.location_meta_data_id);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(shape_id, shape_polygon_id, shape_ring_id, shape_line_string_id, shape_pt_lat, shape_pt_lon,
-            shape_pt_sequence, location_meta_data_id);
-    }
-
-    @Override
-    public String toString() {
-        return "LocationShape{" +
-            "shape_id='" + shape_id + '\'' +
-            ", shape_polygon_id=" + shape_polygon_id +
-            ", shape_ring_id=" + shape_ring_id +
-            ", shape_line_string_id=" + shape_line_string_id +
-            ", shape_pt_lat=" + shape_pt_lat +
-            ", shape_pt_lon=" + shape_pt_lon +
-            ", shape_pt_sequence=" + shape_pt_sequence +
-            ", location_meta_data_id='" + location_meta_data_id + '\'' +
-            '}';
-    }
 }
+
+//    public int shape_polygon_id = INT_MISSING;
+//    public int shape_ring_id = INT_MISSING;
+//    public int shape_line_string_id = INT_MISSING;
+//    public double shape_pt_lat = DOUBLE_MISSING;
+//    public double shape_pt_lon = DOUBLE_MISSING;
+//    public int shape_pt_sequence = INT_MISSING;
+//    public String location_meta_data_id;
+
+//    @Override
+//    public String getId() {
+//        return location_id;
+//    }
+
+//    public int getShape_polygon_id() {
+//        return shape_polygon_id;
+//    }
+
+//    public int getShape_ring_id() {
+//        return shape_ring_id;
+//    }
+
+//    public int getShape_pt_sequence() {
+//        return shape_pt_sequence;
+//    }
+
+//    public int getShape_line_string_id() {
+//        return shape_line_string_id;
+//    }
+
+    /**
+     * Sets the parameters for a prepared statement following the parameter order defined in
+     * {@link com.conveyal.gtfs.loader.Table#LOCATION_SHAPES}. JDBC prepared statement parameters use a one-based index.
+     */
+//    @Override
+//    public void setStatementParameters(PreparedStatement statement, boolean setDefaultId) throws SQLException {
+//        int oneBasedIndex = 1;
+//        if (!setDefaultId) statement.setInt(oneBasedIndex++, id);
+//        statement.setString(oneBasedIndex++, location_id);
+//        statement.setString(oneBasedIndex++, polygon_id);
+//        statement.setString(oneBasedIndex++, geometry_type);
+//        statement.setString()
+////        statement.setString(oneBasedIndex++, location_id);
+////        setIntParameter(statement, oneBasedIndex++, shape_polygon_id);
+////        setIntParameter(statement, oneBasedIndex++, shape_ring_id);
+////        setIntParameter(statement, oneBasedIndex++, shape_line_string_id);
+////        setDoubleParameter(statement, oneBasedIndex++, shape_pt_lat);
+////        setDoubleParameter(statement, oneBasedIndex++, shape_pt_lon);
+////        setIntParameter(statement, oneBasedIndex++, shape_pt_sequence);
+////        statement.setString(oneBasedIndex, location_meta_data_id);
+//    }
+
+//    public static class Loader extends Entity.Loader<LocationShape> {
+//
+//        public Loader(GTFSFeed feed) {
+//            super(feed, "location_shapes");
+//        }
+//
+//        @Override
+//        protected boolean isRequired() {
+//            return false;
+//        }
+//
+//        @Override
+//        public void loadOneRow() throws IOException {
+//            LocationShape locationShape = new LocationShape();
+//            locationShape.id = row + 1; // offset line number by 1 to account for 0-based row index
+//            locationShape.shape_id = getStringField("shape_id", true);
+//            locationShape.shape_polygon_id = getIntField("shape_polygon_id", true, 0, Integer.MAX_VALUE);
+//            locationShape.shape_ring_id = getIntField("shape_ring_id", true, 0, Integer.MAX_VALUE);
+//            locationShape.shape_line_string_id = getIntField("shape_line_string_id", true, 0, Integer.MAX_VALUE);
+//            locationShape.shape_pt_lat = getDoubleField("shape_pt_lat", true, 0D, Double.MAX_VALUE);
+//            locationShape.shape_pt_lon = getDoubleField("shape_pt_lon", true, 0D, Double.MAX_VALUE);
+//            locationShape.shape_pt_sequence = getIntField("shape_pt_sequence", true, 0, Integer.MAX_VALUE);
+//            locationShape.location_meta_data_id = getStringField("location_meta_data_id", true);
+//
+//            // Attempting to put a null key or value will cause an NPE in BTreeMap
+//            if (locationShape.shape_id != null) {
+//                feed.locationShapes.put(locationShape.shape_id, locationShape);
+//            }
+//        }
+//    }
+
+    /**
+     * Required by {@link com.conveyal.gtfs.util.GeoJsonUtil#getCsvReaderFromGeoJson(String, ZipFile, ZipEntry)} as part
+     * of the unpacking of GeoJson data to CSV.
+     */
+//    public static String header() {
+//        return "shape_id,shape_polygon_id,shape_ring_id,shape_line_string_id,shape_pt_lat,shape_pt_lon,shape_pt_sequence,location_meta_data_id\n";
+//    }
+
+    /**
+     * Required by {@link com.conveyal.gtfs.util.GeoJsonUtil#getCsvReaderFromGeoJson(String, ZipFile, ZipEntry)} as part
+     * of the unpacking of GeoJson data to CSV.
+     */
+//    public String toCsvRow() {
+//        return shape_id + "," +
+//            shape_polygon_id + "," +
+//            shape_ring_id + "," +
+//            shape_line_string_id + "," +
+//            shape_pt_lat + "," +
+//            shape_pt_lon + "," +
+//            shape_pt_sequence + "," +
+//            location_meta_data_id + "\n";
+//    }
+
+//    @Override
+//    public boolean equals(Object o) {
+//        if (this == o) return true;
+//        if (o == null || getClass() != o.getClass()) return false;
+//        LocationShape that = (LocationShape) o;
+//        return shape_polygon_id == that.shape_polygon_id &&
+//            shape_ring_id == that.shape_ring_id &&
+//            shape_line_string_id == that.shape_line_string_id &&
+//            Double.compare(that.shape_pt_lat, shape_pt_lat) == 0 &&
+//            Double.compare(that.shape_pt_lon, shape_pt_lon) == 0 &&
+//            shape_pt_sequence == that.shape_pt_sequence &&
+//            Objects.equals(shape_id, that.shape_id) &&
+//            Objects.equals(location_meta_data_id, that.location_meta_data_id);
+//    }
+
+//    @Override
+//    public int hashCode() {
+//        return Objects.hash(shape_id, shape_polygon_id, shape_ring_id, shape_line_string_id, shape_pt_lat, shape_pt_lon,
+//            shape_pt_sequence, location_meta_data_id);
+//    }
+
+//    @Override
+//    public String toString() {
+//        return "LocationShape{" +
+//            "location_id='" + location_id + '\'' +
+//            ", polygon_id=" + polygon_id +
+//            ", geometry_type=" + geometry_type +
+//            '}';
+//    }
+//}

--- a/src/main/java/com/conveyal/gtfs/util/GeoJsonUtil.java
+++ b/src/main/java/com/conveyal/gtfs/util/GeoJsonUtil.java
@@ -1,483 +1,483 @@
-package com.conveyal.gtfs.util;
-
-import com.conveyal.gtfs.loader.Table;
-import com.conveyal.gtfs.model.LocationMetaData;
-import com.conveyal.gtfs.model.LocationShape;
-import com.csvreader.CsvReader;
-import mil.nga.sf.Geometry;
-import mil.nga.sf.LineString;
-import mil.nga.sf.MultiLineString;
-import mil.nga.sf.MultiPolygon;
-import mil.nga.sf.Point;
-import mil.nga.sf.Polygon;
-import mil.nga.sf.geojson.Feature;
-import mil.nga.sf.geojson.FeatureCollection;
-import mil.nga.sf.geojson.FeatureConverter;
-import org.apache.commons.io.input.BOMInputStream;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.StringReader;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
-
-import static java.util.stream.Collectors.toList;
-
-/**
- * With the aid of this third party library: https://ngageoint.github.io/simple-features-geojson-java/, this util class
- * handles the unpacking and packing of GeoJson data. Unpacking flattens the location data into two classes
- * {@link LocationMetaData} and {@link LocationShape}. Packing does the opposite by using these two classes to convert
- * the data back into validate GeoJson.
- */
-public class GeoJsonUtil {
-
-    private static final Logger LOG = LoggerFactory.getLogger(GeoJsonUtil.class);
-
-    /**
-     * If a particular reference id is not required when unpacking locations this value is used as a placeholder. This
-     * is then referenced when packing locations to focus in on a particular geometry type.
-     */
-    private static final int NOT_REQUIRED = -1;
-
-    private static final String PROP_KEY_VALUE_SEPARATOR = "~";
-    private static final String PROP_SEPARATOR = "#";
-
-    /**
-     * Takes the content of a zip file entry and converts it into a {@link FeatureCollection} which is a class
-     * representation of features held in the locations file.
-     */
-    private static FeatureCollection getLocations(ZipFile zipFile, ZipEntry entry) {
-        try (InputStream zipInputStream = zipFile.getInputStream(entry)) {
-            String content;
-            try (InputStream bomInputStream = new BOMInputStream(zipInputStream)) {
-                content = new BufferedReader(
-                    new InputStreamReader(bomInputStream, StandardCharsets.UTF_8))
-                    .lines()
-                    .collect(Collectors.joining("\n")
-                    );
-            }
-            return FeatureConverter.toFeatureCollection(content);
-        } catch (IOException e) {
-            LOG.error("Exception while opening zip entry: ", e);
-            e.printStackTrace();
-            return null;
-        }
-    }
-
-    /**
-     * Extract from a list of features, the items which are common to all features.
-     */
-    private static List<LocationMetaData> unpackLocationMetaData(FeatureCollection featureCollection) {
-        ArrayList<LocationMetaData> locationMetaData = new ArrayList<>();
-        List<Feature> features = featureCollection.getFeatures();
-        for (Feature feature : features) {
-            LocationMetaData location = new LocationMetaData();
-            location.location_meta_data_id = feature.getId();
-            location.geometry_type = feature.getGeometryType().getName();
-            Map<String, Object> props = feature.getProperties();
-            // To avoid any comma related issues when reading this data in, the PROP_KEY_VALUE_SEPARATOR
-            // and PROP_SEPARATOR characters are used.
-            location.properties = props.keySet().stream()
-                .map(key -> key + PROP_KEY_VALUE_SEPARATOR + props.get(key))
-                .collect(Collectors.joining(PROP_SEPARATOR));
-            locationMetaData.add(location);
-
-        }
-        return locationMetaData;
-    }
-
-    /**
-     * Extract from a list of features the different geometry types and produce the appropriate {@link LocationShape}
-     * representing this geometry type so that enough information is available to revert it back to GeoJson.
-     *
-     * GeoJson format reference: https://datatracker.ietf.org/doc/html/rfc7946#section-3.1.4
-     */
-    private static List<LocationShape> unpackLocationShapes(FeatureCollection featureCollection)
-        throws GeoJsonException {
-
-        ArrayList<LocationShape> locationShapes = new ArrayList<>();
-        List<Feature> features = featureCollection.getFeatures();
-        int shapeId = 1;
-        int ringId;
-        int sequenceId;
-        int lineId;
-        for (Feature feature : features) {
-            Geometry geometry = feature.getFeature().getGeometry();
-            switch(geometry.getGeometryType()) {
-                case MULTIPOLYGON:
-                    MultiPolygon multiPolygon = (MultiPolygon) geometry;
-                    List<Polygon> polygons = multiPolygon.getPolygons();
-                    int polygonId = 0;
-                    for (Polygon polygon : polygons) {
-                        polygonId++;
-                        ringId = 0;
-                        for (LineString lineString : polygon.getRings()) {
-                            List<Point> points = lineString.getPoints();
-                            ringId++;
-                            sequenceId = 1;
-                            for (Point point : points) {
-                                locationShapes.add(
-                                    buildLocationShape(shapeId++, polygonId, ringId, point, sequenceId++, feature.getId())
-                                );
-                            }
-                        }
-                    }
-                    break;
-                case POLYGON:
-                    Polygon polygon = (Polygon) geometry;
-                    ringId = 0;
-                    // Assumption, the first ring is the exterior ring and all subsequent rings are interior.
-                    for (LineString lineString : polygon.getRings()) {
-                        List<Point> points = lineString.getPoints();
-                        ringId++;
-                        sequenceId = 1;
-                        for (Point point : points) {
-                            locationShapes.add(buildLocationShape(shapeId++, ringId, point, sequenceId++, feature.getId()));
-                        }
-                    }
-                    break;
-                case MULTILINESTRING:
-                    MultiLineString multiLineString = (MultiLineString) geometry;
-                    List<LineString> lineStrings = multiLineString.getLineStrings();
-                    lineId = 0;
-                    for(LineString lineString : lineStrings) {
-                        List<Point> points = lineString.getPoints();
-                        sequenceId = 1;
-                        lineId++;
-                        for (Point point : points) {
-                            locationShapes.add(buildLocationShape(shapeId++, point, lineId, sequenceId++, feature.getId()));
-                        }
-                    }
-                    break;
-                case LINESTRING:
-                    LineString lineString = (LineString) geometry;
-                    List<Point> points = lineString.getPoints();
-                    sequenceId = 1;
-                    lineId = 1;
-                    for (Point point : points) {
-                        locationShapes.add(buildLocationShape(shapeId++, point, lineId, sequenceId++, feature.getId()));
-                    }
-                    break;
-                default:
-                    String message = String.format("Geometry type %s unknown or not supported.", geometry.getGeometryType());
-                    LOG.warn(message);
-                    throw new GeoJsonException(message);
-            }
-        }
-        return locationShapes;
-    }
-
-    /**
-     * Used to produce a location shape representing a multi line string and line string.
-     */
-    private static LocationShape buildLocationShape(int shapeId, Point point, int lineStringId, int sequenceId, String locationMetaDataId) {
-        return buildLocationShape(shapeId, NOT_REQUIRED, NOT_REQUIRED, point, lineStringId, sequenceId, locationMetaDataId);
-    }
-
-    /**
-     * Used to produce a location shape representing a polygon.
-     */
-    private static LocationShape buildLocationShape(int shapeId, int ringId, Point point, int sequenceId, String locationMetaDataId) {
-        return buildLocationShape(shapeId, NOT_REQUIRED, ringId, point, NOT_REQUIRED, sequenceId, locationMetaDataId);
-    }
-
-    /**
-     * Used to produce a location shape representing a multi-polygon.
-     */
-    private static LocationShape buildLocationShape(int shapeId, int polygonId, int ringId, Point point, int sequenceId, String locationMetaDataId) {
-        return buildLocationShape(shapeId, polygonId, ringId, point, NOT_REQUIRED, sequenceId, locationMetaDataId);
-    }
-
-    /**
-     * Produces a {@link LocationShape} based on the values provided.
-     */
-    private static LocationShape buildLocationShape(
-        int shapeId,
-        int polygonId,
-        int ringId,
-        Point point,
-        int lineStringId,
-        int sequenceId,
-        String locationMetaDataId
-    ) {
-        LocationShape shape = new LocationShape();
-        shape.shape_id = Integer.toString(shapeId);
-        shape.shape_polygon_id = polygonId;
-        shape.shape_ring_id = ringId;
-        shape.shape_line_string_id = lineStringId;
-        shape.shape_pt_lat = point.getX();
-        shape.shape_pt_lon = point.getY();
-        shape.shape_pt_sequence = sequenceId;
-        shape.location_meta_data_id = locationMetaDataId;
-        return shape;
-    }
-
-    /**
-     * Extract the location features from file, unpack and convert to a CSV representation.
-     */
-    public static CsvReader getCsvReaderFromGeoJson(String tableName, ZipFile zipFile, ZipEntry entry)
-        throws GeoJsonException {
-
-        FeatureCollection features = GeoJsonUtil.getLocations(zipFile, entry);
-        if (features == null || features.numFeatures() == 0) {
-            String message = "Unable to extract GeoJson features (or none are available) from " +  entry.getName();
-            LOG.warn(message);
-            throw new GeoJsonException(message);
-        }
-        StringBuilder csvContent = new StringBuilder();
-        if (tableName.equals(Table.LOCATION_META_DATA.name)) {
-            List<LocationMetaData> locationMetaData = GeoJsonUtil.unpackLocationMetaData(features);
-            csvContent.append(LocationMetaData.header());
-            locationMetaData.forEach(location -> csvContent.append(location.toCsvRow()));
-        } else if (tableName.equals(Table.LOCATION_SHAPES.name)) {
-            List<LocationShape> locationShapes = GeoJsonUtil.unpackLocationShapes(features);
-            csvContent.append(LocationShape.header());
-            locationShapes.forEach(locationShape -> csvContent.append(locationShape.toCsvRow()));
-        }
-        return new CsvReader(new StringReader(csvContent.toString()));
-    }
-
-    /**
-     * Convert {@link LocationMetaData} and {@link LocationShape} lists to a serialized String conforming to the GeoJson
-     * standard.
-     */
-    public static String packLocations(List<LocationMetaData> locationMetaData, List<LocationShape> locationShapes)
-        throws GeoJsonException {
-
-        FeatureCollection featureCollection = new FeatureCollection();
-        List<Feature> features = new ArrayList<>();
-        for (LocationMetaData meta : locationMetaData) {
-            switch (meta.geometry_type) {
-                case "MULTIPOLYGON":
-                    List<Polygon> polygons = new ArrayList<>();
-                    Map<Integer, List<LocationShape>> polygonsForMetaData = getMultiPolygons(meta.location_meta_data_id, locationShapes);
-                    polygonsForMetaData.forEach((polygonId, multiPolygons) -> {
-                        polygons.add(buildPolygon(multiPolygons));
-                    });
-                    MultiPolygon multiPolygon = new MultiPolygon();
-                    multiPolygon.setPolygons(polygons);
-                    mil.nga.sf.geojson.Feature multiPolygonFeature = new mil.nga.sf.geojson.Feature();
-                    multiPolygonFeature.setGeometry(new mil.nga.sf.geojson.MultiPolygon(multiPolygon));
-                    setFeatureProps(meta, multiPolygonFeature);
-                    features.add(multiPolygonFeature);
-                    break;
-                case "POLYGON":
-                    List<LocationShape> polygonRings = getPolygonRings(meta.location_meta_data_id, locationShapes);
-                    Polygon polygon = buildPolygon(polygonRings);
-                    mil.nga.sf.geojson.Feature polygonFeature = new mil.nga.sf.geojson.Feature();
-                    polygonFeature.setGeometry(new mil.nga.sf.geojson.Polygon(polygon));
-                    setFeatureProps(meta, polygonFeature);
-                    features.add(polygonFeature);
-                    break;
-                case "MULTILINESTRING":
-                    List<LineString> lineStrings = new ArrayList<>();
-                    Map<Integer, List<LocationShape>> multiLineStrings = getMultiLineStings(meta.location_meta_data_id, locationShapes);
-                    multiLineStrings.forEach((lineStringId, lineString) -> {
-                        lineStrings.add(buildLineString(lineString));
-                    });
-                    MultiLineString multiLineString = new MultiLineString();
-                    multiLineString.setLineStrings(lineStrings);
-                    mil.nga.sf.geojson.Feature multiLineStringFeature = new mil.nga.sf.geojson.Feature();
-                    multiLineStringFeature.setGeometry(new mil.nga.sf.geojson.MultiLineString(multiLineString));
-                    setFeatureProps(meta, multiLineStringFeature);
-                    features.add(multiLineStringFeature);
-                    break;
-                case "LINESTRING":
-                    LineString ls = buildLineString(getLineStings(meta.location_meta_data_id, locationShapes));
-                    LineString lineString = new LineString();
-                    lineString.setPoints(ls.getPoints());
-                    mil.nga.sf.geojson.Feature lineStringFeature = new mil.nga.sf.geojson.Feature();
-                    lineStringFeature.setGeometry(new mil.nga.sf.geojson.LineString(lineString));
-                    setFeatureProps(meta, lineStringFeature);
-                    features.add(lineStringFeature);
-                    break;
-                default:
-                    String message = String.format("Geometry type %s unknown or not supported.", meta.geometry_type);
-                    LOG.warn(message);
-                    throw new GeoJsonException(message);
-            }
-        }
-        featureCollection.setFeatures(features);
-        return FeatureConverter.toStringValue(featureCollection);
-    }
-
-    /**
-     * Set the feature id and properties value based on the values held in {@link LocationMetaData}.
-     */
-    private static void setFeatureProps(LocationMetaData metaData, Feature feature) {
-        feature.setId(metaData.location_meta_data_id);
-        if (!metaData.properties.isEmpty()) {
-            String[] props = metaData.properties.split(PROP_SEPARATOR);
-            Map<String, Object> properties = new HashMap<>();
-            Arrays.stream(props).forEach(prop -> {
-                String key = prop.split(PROP_KEY_VALUE_SEPARATOR)[0];
-                String value = prop.split(PROP_KEY_VALUE_SEPARATOR)[1];
-                properties.put(key, value);
-            });
-            feature.setProperties(properties);
-        }
-    }
-
-    /**
-     * Produce a single {@link Polygon} from multiple {@link LocationShape} entries.
-     */
-    private static Polygon buildPolygon(List<LocationShape> polygons) {
-        Polygon polygon = new Polygon();
-        List<LineString> lineStrings = new ArrayList<>();
-        Map<Integer, List<LocationShape>> ringsForPolygons = getPolygonRings(polygons);
-        ringsForPolygons.forEach((ringId, rings) -> {
-            lineStrings.add(buildLineString(rings));
-        });
-        polygon.setRings(lineStrings);
-        return polygon;
-    }
-
-    /**
-     * Produce a single {@link LineString} from multiple {@link LocationShape} entries.
-     */
-    private static LineString buildLineString(List<LocationShape> rings) {
-        List<Point> points = buildPoints(rings);
-        LineString lineString = new LineString();
-        lineString.setPoints(points);
-        return lineString;
-    }
-
-    /**
-     * Produce a list of {@link Point}s from multiple {@link LocationShape} entries.
-     */
-    private static List<Point> buildPoints(List<LocationShape> locationShapes) {
-        List<Point> points = new ArrayList<>();
-        locationShapes.forEach(locationShape -> {
-            points.add(new Point(locationShape.shape_pt_lat, locationShape.shape_pt_lon));
-        });
-        return points;
-    }
-
-    /**
-     * From the provided list of {@link LocationShape}s group by {@link LocationShape#shape_ring_id}.
-     */
-    private static Map<Integer, List<LocationShape>> getPolygonRings(
-        List<LocationShape> locationShapes
-    ) {
-        return locationShapes
-            .stream()
-            .collect(
-                Collectors.groupingBy(
-                    LocationShape::getShape_ring_id,
-                    Collectors.mapping((LocationShape l) -> l, toList())
-                )
-            );
-    }
-
-    /**
-     * From the provided list of {@link LocationShape}s extract all polygon entries and group by polygon id.
-     */
-    private static Map<Integer, List<LocationShape>> getMultiPolygons(
-        String locationMetaDataId,
-        List<LocationShape> locationShapes
-    ) {
-        return locationShapes
-            .stream()
-            .filter(
-                item -> item.shape_polygon_id != NOT_REQUIRED &&
-                item.location_meta_data_id.equals(locationMetaDataId)
-            )
-            .sorted(
-                Comparator
-                    .comparing(LocationShape::getShape_polygon_id)
-                    .thenComparing(LocationShape::getShape_ring_id)
-                    .thenComparing(LocationShape::getShape_pt_sequence)
-            )
-            .collect(
-                Collectors.groupingBy(
-                    LocationShape::getShape_polygon_id,
-                    Collectors.mapping((LocationShape l) -> l, toList())
-                )
-            );
-    }
-
-    /**
-     * From the provided list of {@link LocationShape}s extract all rings entries.
-     */
-    private static List<LocationShape> getPolygonRings(
-        String locationMetaDataId,
-        List<LocationShape> locationShapes
-    ) {
-        return locationShapes
-            .stream()
-            .filter(
-                item -> item.shape_polygon_id == NOT_REQUIRED &&
-                item.shape_ring_id != NOT_REQUIRED &&
-                item.location_meta_data_id.equals(locationMetaDataId)
-            )
-            .sorted(
-                Comparator
-                    .comparing(LocationShape::getShape_ring_id)
-                    .thenComparing(LocationShape::getShape_pt_sequence)
-            )
-            .collect(toList());
-    }
-
-    /**
-     * From the provided list of {@link LocationShape}s extract all line string entries and group by line string id.
-     */
-    private static Map<Integer, List<LocationShape>> getMultiLineStings(
-        String locationMetaDataId,
-        List<LocationShape> locationShapes
-    ) {
-        return locationShapes
-            .stream()
-            .filter(
-                item -> item.shape_polygon_id == NOT_REQUIRED &&
-                item.shape_ring_id == NOT_REQUIRED &&
-                item.shape_line_string_id != NOT_REQUIRED &&
-                item.location_meta_data_id.equals(locationMetaDataId)
-            )
-            .sorted(
-                Comparator
-                    .comparing(LocationShape::getShape_line_string_id)
-                    .thenComparing(LocationShape::getShape_pt_sequence)
-            )
-            .collect(
-                Collectors.groupingBy(
-                    LocationShape::getShape_line_string_id,
-                    Collectors.mapping((LocationShape l) -> l, toList())
-                )
-            );
-    }
-
-    /**
-     * From the provided list of {@link LocationShape}s extract all line string entries and group by line string id.
-     */
-    private static List<LocationShape> getLineStings(
-        String locationMetaDataId,
-        List<LocationShape> locationShapes
-    ) {
-        return locationShapes
-            .stream()
-            .filter(
-                item -> item.shape_polygon_id == NOT_REQUIRED &&
-                    item.shape_ring_id == NOT_REQUIRED &&
-                    item.shape_line_string_id != NOT_REQUIRED &&
-                    item.location_meta_data_id.equals(locationMetaDataId)
-            )
-            .sorted(
-                Comparator
-                    .comparing(LocationShape::getShape_line_string_id)
-                    .thenComparing(LocationShape::getShape_pt_sequence)
-            )
-            .collect(toList());
-    }
-}
+//package com.conveyal.gtfs.util;
+//
+//import com.conveyal.gtfs.loader.Table;
+//import com.conveyal.gtfs.model.LocationMetaData;
+//import com.conveyal.gtfs.model.LocationShape;
+//import com.csvreader.CsvReader;
+//import mil.nga.sf.Geometry;
+//import mil.nga.sf.LineString;
+//import mil.nga.sf.MultiLineString;
+//import mil.nga.sf.MultiPolygon;
+//import mil.nga.sf.Point;
+//import mil.nga.sf.Polygon;
+//import mil.nga.sf.geojson.Feature;
+//import mil.nga.sf.geojson.FeatureCollection;
+//import mil.nga.sf.geojson.FeatureConverter;
+//import org.apache.commons.io.input.BOMInputStream;
+//import org.slf4j.Logger;
+//import org.slf4j.LoggerFactory;
+//
+//import java.io.BufferedReader;
+//import java.io.IOException;
+//import java.io.InputStream;
+//import java.io.InputStreamReader;
+//import java.io.StringReader;
+//import java.nio.charset.StandardCharsets;
+//import java.util.ArrayList;
+//import java.util.Arrays;
+//import java.util.Comparator;
+//import java.util.HashMap;
+//import java.util.List;
+//import java.util.Map;
+//import java.util.stream.Collectors;
+//import java.util.zip.ZipEntry;
+//import java.util.zip.ZipFile;
+//
+//import static java.util.stream.Collectors.toList;
+//
+///**
+// * With the aid of this third party library: https://ngageoint.github.io/simple-features-geojson-java/, this util class
+// * handles the unpacking and packing of GeoJson data. Unpacking flattens the location data into two classes
+// * {@link LocationMetaData} and {@link LocationShape}. Packing does the opposite by using these two classes to convert
+// * the data back into validate GeoJson.
+// */
+//public class GeoJsonUtil {
+//
+//    private static final Logger LOG = LoggerFactory.getLogger(GeoJsonUtil.class);
+//
+//    /**
+//     * If a particular reference id is not required when unpacking locations this value is used as a placeholder. This
+//     * is then referenced when packing locations to focus in on a particular geometry type.
+//     */
+//    private static final int NOT_REQUIRED = -1;
+//
+//    private static final String PROP_KEY_VALUE_SEPARATOR = "~";
+//    private static final String PROP_SEPARATOR = "#";
+//
+//    /**
+//     * Takes the content of a zip file entry and converts it into a {@link FeatureCollection} which is a class
+//     * representation of features held in the locations file.
+//     */
+//    private static FeatureCollection getLocations(ZipFile zipFile, ZipEntry entry) {
+//        try (InputStream zipInputStream = zipFile.getInputStream(entry)) {
+//            String content;
+//            try (InputStream bomInputStream = new BOMInputStream(zipInputStream)) {
+//                content = new BufferedReader(
+//                    new InputStreamReader(bomInputStream, StandardCharsets.UTF_8))
+//                    .lines()
+//                    .collect(Collectors.joining("\n")
+//                    );
+//            }
+//            return FeatureConverter.toFeatureCollection(content);
+//        } catch (IOException e) {
+//            LOG.error("Exception while opening zip entry: ", e);
+//            e.printStackTrace();
+//            return null;
+//        }
+//    }
+//
+//    /**
+//     * Extract from a list of features, the items which are common to all features.
+//     */
+//    private static List<LocationMetaData> unpackLocationMetaData(FeatureCollection featureCollection) {
+//        ArrayList<LocationMetaData> locationMetaData = new ArrayList<>();
+//        List<Feature> features = featureCollection.getFeatures();
+//        for (Feature feature : features) {
+//            LocationMetaData location = new LocationMetaData();
+//            location.location_meta_data_id = feature.getId();
+//            location.geometry_type = feature.getGeometryType().getName();
+//            Map<String, Object> props = feature.getProperties();
+//            // To avoid any comma related issues when reading this data in, the PROP_KEY_VALUE_SEPARATOR
+//            // and PROP_SEPARATOR characters are used.
+//            location.properties = props.keySet().stream()
+//                .map(key -> key + PROP_KEY_VALUE_SEPARATOR + props.get(key))
+//                .collect(Collectors.joining(PROP_SEPARATOR));
+//            locationMetaData.add(location);
+//
+//        }
+//        return locationMetaData;
+//    }
+//
+//    /**
+//     * Extract from a list of features the different geometry types and produce the appropriate {@link LocationShape}
+//     * representing this geometry type so that enough information is available to revert it back to GeoJson.
+//     *
+//     * GeoJson format reference: https://datatracker.ietf.org/doc/html/rfc7946#section-3.1.4
+//     */
+//    private static List<LocationShape> unpackLocationShapes(FeatureCollection featureCollection)
+//        throws GeoJsonException {
+//
+//        ArrayList<LocationShape> locationShapes = new ArrayList<>();
+//        List<Feature> features = featureCollection.getFeatures();
+//        int shapeId = 1;
+//        int ringId;
+//        int sequenceId;
+//        int lineId;
+//        for (Feature feature : features) {
+//            Geometry geometry = feature.getFeature().getGeometry();
+//            switch(geometry.getGeometryType()) {
+//                case MULTIPOLYGON:
+//                    MultiPolygon multiPolygon = (MultiPolygon) geometry;
+//                    List<Polygon> polygons = multiPolygon.getPolygons();
+//                    int polygonId = 0;
+//                    for (Polygon polygon : polygons) {
+//                        polygonId++;
+//                        ringId = 0;
+//                        for (LineString lineString : polygon.getRings()) {
+//                            List<Point> points = lineString.getPoints();
+//                            ringId++;
+//                            sequenceId = 1;
+//                            for (Point point : points) {
+//                                locationShapes.add(
+//                                    buildLocationShape(shapeId++, polygonId, ringId, point, sequenceId++, feature.getId())
+//                                );
+//                            }
+//                        }
+//                    }
+//                    break;
+//                case POLYGON:
+//                    Polygon polygon = (Polygon) geometry;
+//                    ringId = 0;
+//                    // Assumption, the first ring is the exterior ring and all subsequent rings are interior.
+//                    for (LineString lineString : polygon.getRings()) {
+//                        List<Point> points = lineString.getPoints();
+//                        ringId++;
+//                        sequenceId = 1;
+//                        for (Point point : points) {
+//                            locationShapes.add(buildLocationShape(shapeId++, ringId, point, sequenceId++, feature.getId()));
+//                        }
+//                    }
+//                    break;
+//                case MULTILINESTRING:
+//                    MultiLineString multiLineString = (MultiLineString) geometry;
+//                    List<LineString> lineStrings = multiLineString.getLineStrings();
+//                    lineId = 0;
+//                    for(LineString lineString : lineStrings) {
+//                        List<Point> points = lineString.getPoints();
+//                        sequenceId = 1;
+//                        lineId++;
+//                        for (Point point : points) {
+//                            locationShapes.add(buildLocationShape(shapeId++, point, lineId, sequenceId++, feature.getId()));
+//                        }
+//                    }
+//                    break;
+//                case LINESTRING:
+//                    LineString lineString = (LineString) geometry;
+//                    List<Point> points = lineString.getPoints();
+//                    sequenceId = 1;
+//                    lineId = 1;
+//                    for (Point point : points) {
+//                        locationShapes.add(buildLocationShape(shapeId++, point, lineId, sequenceId++, feature.getId()));
+//                    }
+//                    break;
+//                default:
+//                    String message = String.format("Geometry type %s unknown or not supported.", geometry.getGeometryType());
+//                    LOG.warn(message);
+//                    throw new GeoJsonException(message);
+//            }
+//        }
+//        return locationShapes;
+//    }
+//
+//    /**
+//     * Used to produce a location shape representing a multi line string and line string.
+//     */
+//    private static LocationShape buildLocationShape(int shapeId, Point point, int lineStringId, int sequenceId, String locationMetaDataId) {
+//        return buildLocationShape(shapeId, NOT_REQUIRED, NOT_REQUIRED, point, lineStringId, sequenceId, locationMetaDataId);
+//    }
+//
+//    /**
+//     * Used to produce a location shape representing a polygon.
+//     */
+//    private static LocationShape buildLocationShape(int shapeId, int ringId, Point point, int sequenceId, String locationMetaDataId) {
+//        return buildLocationShape(shapeId, NOT_REQUIRED, ringId, point, NOT_REQUIRED, sequenceId, locationMetaDataId);
+//    }
+//
+//    /**
+//     * Used to produce a location shape representing a multi-polygon.
+//     */
+//    private static LocationShape buildLocationShape(int shapeId, int polygonId, int ringId, Point point, int sequenceId, String locationMetaDataId) {
+//        return buildLocationShape(shapeId, polygonId, ringId, point, NOT_REQUIRED, sequenceId, locationMetaDataId);
+//    }
+//
+//    /**
+//     * Produces a {@link LocationShape} based on the values provided.
+//     */
+//    private static LocationShape buildLocationShape(
+//        int shapeId,
+//        int polygonId,
+//        int ringId,
+//        Point point,
+//        int lineStringId,
+//        int sequenceId,
+//        String locationMetaDataId
+//    ) {
+//        LocationShape shape = new LocationShape();
+////        shape.shape_id = Integer.toString(shapeId);
+////        shape.shape_polygon_id = polygonId;
+////        shape.shape_ring_id = ringId;
+////        shape.shape_line_string_id = lineStringId;
+////        shape.shape_pt_lat = point.getX();
+////        shape.shape_pt_lon = point.getY();
+////        shape.shape_pt_sequence = sequenceId;
+////        shape.location_meta_data_id = locationMetaDataId;
+//        return shape;
+//    }
+//
+//    /**
+//     * Extract the location features from file, unpack and convert to a CSV representation.
+//     */
+//    public static CsvReader getCsvReaderFromGeoJson(String tableName, ZipFile zipFile, ZipEntry entry)
+//        throws GeoJsonException {
+//
+//        FeatureCollection features = GeoJsonUtil.getLocations(zipFile, entry);
+//        if (features == null || features.numFeatures() == 0) {
+//            String message = "Unable to extract GeoJson features (or none are available) from " +  entry.getName();
+//            LOG.warn(message);
+//            throw new GeoJsonException(message);
+//        }
+//        StringBuilder csvContent = new StringBuilder();
+//        if (tableName.equals(Table.LOCATION_META_DATA.name)) {
+//            List<LocationMetaData> locationMetaData = GeoJsonUtil.unpackLocationMetaData(features);
+//            csvContent.append(LocationMetaData.header());
+//            locationMetaData.forEach(location -> csvContent.append(location.toCsvRow()));
+//        } else if (tableName.equals(Table.LOCATION_SHAPES.name)) {
+//            List<LocationShape> locationShapes = GeoJsonUtil.unpackLocationShapes(features);
+////            csvContent.append(LocationShape.header());
+////            locationShapes.forEach(locationShape -> csvContent.append(locationShape.toCsvRow()));
+//        }
+//        return new CsvReader(new StringReader(csvContent.toString()));
+//    }
+//
+//    /**
+//     * Convert {@link LocationMetaData} and {@link LocationShape} lists to a serialized String conforming to the GeoJson
+//     * standard.
+//     */
+//    public static String packLocations(List<LocationMetaData> locationMetaData, List<LocationShape> locationShapes)
+//        throws GeoJsonException {
+//
+//        FeatureCollection featureCollection = new FeatureCollection();
+//        List<Feature> features = new ArrayList<>();
+//        for (LocationMetaData meta : locationMetaData) {
+//            switch (meta.geometry_type) {
+//                case "MULTIPOLYGON":
+//                    List<Polygon> polygons = new ArrayList<>();
+//                    Map<Integer, List<LocationShape>> polygonsForMetaData = getMultiPolygons(meta.location_meta_data_id, locationShapes);
+//                    polygonsForMetaData.forEach((polygonId, multiPolygons) -> {
+//                        polygons.add(buildPolygon(multiPolygons));
+//                    });
+//                    MultiPolygon multiPolygon = new MultiPolygon();
+//                    multiPolygon.setPolygons(polygons);
+//                    mil.nga.sf.geojson.Feature multiPolygonFeature = new mil.nga.sf.geojson.Feature();
+//                    multiPolygonFeature.setGeometry(new mil.nga.sf.geojson.MultiPolygon(multiPolygon));
+//                    setFeatureProps(meta, multiPolygonFeature);
+//                    features.add(multiPolygonFeature);
+//                    break;
+//                case "POLYGON":
+//                    List<LocationShape> polygonRings = getPolygonRings(meta.location_meta_data_id, locationShapes);
+//                    Polygon polygon = buildPolygon(polygonRings);
+//                    mil.nga.sf.geojson.Feature polygonFeature = new mil.nga.sf.geojson.Feature();
+//                    polygonFeature.setGeometry(new mil.nga.sf.geojson.Polygon(polygon));
+//                    setFeatureProps(meta, polygonFeature);
+//                    features.add(polygonFeature);
+//                    break;
+//                case "MULTILINESTRING":
+//                    List<LineString> lineStrings = new ArrayList<>();
+//                    Map<Integer, List<LocationShape>> multiLineStrings = getMultiLineStings(meta.location_meta_data_id, locationShapes);
+//                    multiLineStrings.forEach((lineStringId, lineString) -> {
+//                        lineStrings.add(buildLineString(lineString));
+//                    });
+//                    MultiLineString multiLineString = new MultiLineString();
+//                    multiLineString.setLineStrings(lineStrings);
+//                    mil.nga.sf.geojson.Feature multiLineStringFeature = new mil.nga.sf.geojson.Feature();
+//                    multiLineStringFeature.setGeometry(new mil.nga.sf.geojson.MultiLineString(multiLineString));
+//                    setFeatureProps(meta, multiLineStringFeature);
+//                    features.add(multiLineStringFeature);
+//                    break;
+//                case "LINESTRING":
+//                    LineString ls = buildLineString(getLineStings(meta.location_meta_data_id, locationShapes));
+//                    LineString lineString = new LineString();
+//                    lineString.setPoints(ls.getPoints());
+//                    mil.nga.sf.geojson.Feature lineStringFeature = new mil.nga.sf.geojson.Feature();
+//                    lineStringFeature.setGeometry(new mil.nga.sf.geojson.LineString(lineString));
+//                    setFeatureProps(meta, lineStringFeature);
+//                    features.add(lineStringFeature);
+//                    break;
+//                default:
+//                    String message = String.format("Geometry type %s unknown or not supported.", meta.geometry_type);
+//                    LOG.warn(message);
+//                    throw new GeoJsonException(message);
+//            }
+//        }
+//        featureCollection.setFeatures(features);
+//        return FeatureConverter.toStringValue(featureCollection);
+//    }
+//
+//    /**
+//     * Set the feature id and properties value based on the values held in {@link LocationMetaData}.
+//     */
+//    private static void setFeatureProps(LocationMetaData metaData, Feature feature) {
+//        feature.setId(metaData.location_meta_data_id);
+//        if (!metaData.properties.isEmpty()) {
+//            String[] props = metaData.properties.split(PROP_SEPARATOR);
+//            Map<String, Object> properties = new HashMap<>();
+//            Arrays.stream(props).forEach(prop -> {
+//                String key = prop.split(PROP_KEY_VALUE_SEPARATOR)[0];
+//                String value = prop.split(PROP_KEY_VALUE_SEPARATOR)[1];
+//                properties.put(key, value);
+//            });
+//            feature.setProperties(properties);
+//        }
+//    }
+//
+//    /**
+//     * Produce a single {@link Polygon} from multiple {@link LocationShape} entries.
+//     */
+////    private static Polygon buildPolygon(List<LocationShape> polygons) {
+////        Polygon polygon = new Polygon();
+////        List<LineString> lineStrings = new ArrayList<>();
+////        Map<Integer, List<LocationShape>> ringsForPolygons = getPolygonRings(polygons);
+////        ringsForPolygons.forEach((ringId, rings) -> {
+////            lineStrings.add(buildLineString(rings));
+////        });
+////        polygon.setRings(lineStrings);
+////        return polygon;
+////    }
+//
+//    /**
+//     * Produce a single {@link LineString} from multiple {@link LocationShape} entries.
+//     */
+//    private static LineString buildLineString(List<LocationShape> rings) {
+//        List<Point> points = buildPoints(rings);
+//        LineString lineString = new LineString();
+//        lineString.setPoints(points);
+//        return lineString;
+//    }
+//
+//    /**
+//     * Produce a list of {@link Point}s from multiple {@link LocationShape} entries.
+//     */
+//    private static List<Point> buildPoints(List<LocationShape> locationShapes) {
+//        List<Point> points = new ArrayList<>();
+////        locationShapes.forEach(locationShape -> {
+////            points.add(new Point(locationShape.shape_pt_lat, locationShape.shape_pt_lon));
+////        });
+//        return points;
+//    }
+//
+//    /**
+//     * From the provided list of {@link LocationShape}s group by {@link LocationShape#shape_ring_id}.
+//     */
+////    private static Map<Integer, List<LocationShape>> getPolygonRings(
+////        List<LocationShape> locationShapes
+////    ) {
+////        return locationShapes
+////            .stream()
+////            .collect(
+////                Collectors.groupingBy(
+////                    LocationShape::getShape_ring_id,
+////                    Collectors.mapping((LocationShape l) -> l, toList())
+////                )
+////            );
+////    }
+//
+//    /**
+//     * From the provided list of {@link LocationShape}s extract all polygon entries and group by polygon id.
+//     */
+//    private static Map<Integer, List<LocationShape>> getMultiPolygons(
+//        String locationMetaDataId,
+//        List<LocationShape> locationShapes
+//    ) {
+//        return locationShapes
+//            .stream()
+//            .filter(
+//                item -> item.shape_polygon_id != NOT_REQUIRED &&
+//                item.location_meta_data_id.equals(locationMetaDataId)
+//            )
+//            .sorted(
+//                Comparator
+//                    .comparing(LocationShape::getShape_polygon_id)
+//                    .thenComparing(LocationShape::getShape_ring_id)
+//                    .thenComparing(LocationShape::getShape_pt_sequence)
+//            )
+//            .collect(
+//                Collectors.groupingBy(
+//                    LocationShape::getShape_polygon_id,
+//                    Collectors.mapping((LocationShape l) -> l, toList())
+//                )
+//            );
+//    }
+//
+//    /**
+//     * From the provided list of {@link LocationShape}s extract all rings entries.
+//     */
+//    private static List<LocationShape> getPolygonRings(
+//        String locationMetaDataId,
+//        List<LocationShape> locationShapes
+//    ) {
+//        return locationShapes
+//            .stream()
+//            .filter(
+//                item -> item.shape_polygon_id == NOT_REQUIRED &&
+//                item.shape_ring_id != NOT_REQUIRED &&
+//                item.location_meta_data_id.equals(locationMetaDataId)
+//            )
+//            .sorted(
+//                Comparator
+//                    .comparing(LocationShape::getShape_ring_id)
+//                    .thenComparing(LocationShape::getShape_pt_sequence)
+//            )
+//            .collect(toList());
+//    }
+//
+//    /**
+//     * From the provided list of {@link LocationShape}s extract all line string entries and group by line string id.
+//     */
+//    private static Map<Integer, List<LocationShape>> getMultiLineStings(
+//        String locationMetaDataId,
+//        List<LocationShape> locationShapes
+//    ) {
+//        return locationShapes
+//            .stream()
+//            .filter(
+//                item -> item.shape_polygon_id == NOT_REQUIRED &&
+//                item.shape_ring_id == NOT_REQUIRED &&
+//                item.shape_line_string_id != NOT_REQUIRED &&
+//                item.location_meta_data_id.equals(locationMetaDataId)
+//            )
+//            .sorted(
+//                Comparator
+//                    .comparing(LocationShape::getShape_line_string_id)
+//                    .thenComparing(LocationShape::getShape_pt_sequence)
+//            )
+//            .collect(
+//                Collectors.groupingBy(
+//                    LocationShape::getShape_line_string_id,
+//                    Collectors.mapping((LocationShape l) -> l, toList())
+//                )
+//            );
+//    }
+//
+//    /**
+//     * From the provided list of {@link LocationShape}s extract all line string entries and group by line string id.
+//     */
+//    private static List<LocationShape> getLineStings(
+//        String locationMetaDataId,
+//        List<LocationShape> locationShapes
+//    ) {
+//        return locationShapes
+//            .stream()
+//            .filter(
+//                item -> item.shape_polygon_id == NOT_REQUIRED &&
+//                    item.shape_ring_id == NOT_REQUIRED &&
+//                    item.shape_line_string_id != NOT_REQUIRED &&
+//                    item.location_meta_data_id.equals(locationMetaDataId)
+//            )
+//            .sorted(
+//                Comparator
+//                    .comparing(LocationShape::getShape_line_string_id)
+//                    .thenComparing(LocationShape::getShape_pt_sequence)
+//            )
+//            .collect(toList());
+//    }
+//}


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [ ] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [ ] All tests and CI builds passing

### Description

This is a (very) rough PR which outlines a working prototype that allows saving of flex location shapes through parent 'locations' table. It builds on #335 and refactors mainly the Location, LocationShape, and (especially) the JdbcTableWriter classes. 
