### PR TITLE
Remove rounding to 2 decimals in stop_times.shape_dist_traveled

### DIFF
--- a/src/main/java/com/conveyal/gtfs/loader/Table.java
+++ b/src/main/java/com/conveyal/gtfs/loader/Table.java
@@ -348,7 +348,7 @@ public class Table {
             new ShortField("drop_off_type", OPTIONAL, 3),
             new ShortField("continuous_pickup", OPTIONAL, 3),
             new ShortField("continuous_drop_off", OPTIONAL, 3),
-            new DoubleField("shape_dist_traveled", OPTIONAL, 0, Double.POSITIVE_INFINITY, 2),
+            new DoubleField("shape_dist_traveled", OPTIONAL, 0, Double.POSITIVE_INFINITY, -1),
             new ShortField("timepoint", OPTIONAL, 1),
             new IntegerField("fare_units_traveled", EXTENSION) // OpenOV NL extension
     ).withParentTable(TRIPS);

--- a/src/test/java/com/conveyal/gtfs/GTFSTest.java
+++ b/src/test/java/com/conveyal/gtfs/GTFSTest.java
@@ -278,6 +278,13 @@ public class GTFSTest {
                     new RecordExpectation("shape_dist_traveled", 0.0, 0.01)
                 }
             ),
+            // Check that the shape_dist_traveled values in stop_times are not rounded.
+            new PersistenceExpectation(
+                "stop_times",
+                new RecordExpectation[]{
+                    new RecordExpectation("shape_dist_traveled", 341.4491961, 0.0)
+                }
+            ),
             new PersistenceExpectation(
                 "trips",
                 new RecordExpectation[]{

--- a/src/test/java/com/conveyal/gtfs/GTFSTest.java
+++ b/src/test/java/com/conveyal/gtfs/GTFSTest.java
@@ -282,7 +282,7 @@ public class GTFSTest {
             new PersistenceExpectation(
                 "stop_times",
                 new RecordExpectation[]{
-                    new RecordExpectation("shape_dist_traveled", 341.4491961, 0.0)
+                    new RecordExpectation("shape_dist_traveled", 341.4491961, 0.00001)
                 }
             ),
             new PersistenceExpectation(


### PR DESCRIPTION
Fixes #339 

### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR removes the rounding to two decimal places which causes issue #339 and subsequent validation issues. 
