### PR TITLE
feat(RouteTypeValidator): Add route type validation.

### DIFF
--- a/src/main/java/com/conveyal/gtfs/error/NewGTFSErrorType.java
+++ b/src/main/java/com/conveyal/gtfs/error/NewGTFSErrorType.java
@@ -47,6 +47,7 @@ public enum NewGTFSErrorType {
     ROUTE_LONG_NAME_CONTAINS_SHORT_NAME(Priority.LOW, "The long name of a route should complement the short name, not include it."),
     ROUTE_SHORT_AND_LONG_NAME_MISSING(Priority.MEDIUM, "A route has neither a long nor a short name."),
     ROUTE_SHORT_NAME_TOO_LONG(Priority.MEDIUM, "The short name of a route is too long for display in standard GTFS consumer applications."),
+    ROUTE_TYPE_INVALID(Priority.MEDIUM, "The route type is not valid."),
     ROUTE_UNUSED(Priority.MEDIUM, "This route is defined but has no trips."),
     SERVICE_NEVER_ACTIVE(Priority.MEDIUM, "A service code was defined, but is never active on any date."),
     SERVICE_UNUSED(Priority.MEDIUM, "A service code was defined, but is never referenced by any trips."),

--- a/src/main/java/com/conveyal/gtfs/validator/RouteTypeValidator.java
+++ b/src/main/java/com/conveyal/gtfs/validator/RouteTypeValidator.java
@@ -51,7 +51,6 @@ public class RouteTypeValidator extends FeedValidator {
             if (errorStorage != null) registerError(route, ROUTE_TYPE_INVALID, route.route_type);
             return false;
         }
-
         return true;
     }
 }

--- a/src/main/java/com/conveyal/gtfs/validator/RouteTypeValidator.java
+++ b/src/main/java/com/conveyal/gtfs/validator/RouteTypeValidator.java
@@ -1,0 +1,57 @@
+package com.conveyal.gtfs.validator;
+
+import com.conveyal.gtfs.error.SQLErrorStorage;
+import com.conveyal.gtfs.loader.Feed;
+import com.conveyal.gtfs.model.Route;
+
+import java.util.List;
+
+import static com.conveyal.gtfs.error.NewGTFSErrorType.ROUTE_TYPE_INVALID;
+
+/**
+ * Validates route types based on a configured list of values.
+ */
+public class RouteTypeValidator extends FeedValidator {
+    private final List<Integer> configuredRouteTypes;
+
+    /**
+     * Constructor used for tests in the same package.
+     */
+    RouteTypeValidator(List<Integer> routeTypes) {
+        this(null, null, routeTypes);
+    }
+
+    /**
+     * Constructor for building a route type validator given a set of valid route types.
+     */
+    public RouteTypeValidator(Feed feed, SQLErrorStorage errorStorage, List<Integer> routeTypes) {
+        super(feed, errorStorage);
+        this.configuredRouteTypes = routeTypes;
+    }
+
+    @Override
+    public void validate() {
+        feed.routes.forEach(this::validateRouteType);
+    }
+
+    /**
+     * @return true if routeType is one of the configured route types, false otherwise.
+     */
+    public boolean isRouteTypeValid(int routeType) {
+        return configuredRouteTypes.contains(routeType);
+    }
+
+    /**
+     * Checks that the route type is valid, reports a validation error if not.
+     * @param route The containing GTFS route.
+     * @return true if the route type for the given route is valid, false otherwise.
+     */
+    public boolean validateRouteType(Route route) {
+        if (!isRouteTypeValid(route.route_type)) {
+            if (errorStorage != null) registerError(route, ROUTE_TYPE_INVALID, route.route_type);
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/test/java/com/conveyal/gtfs/validator/RouteTypeValidatorTest.java
+++ b/src/test/java/com/conveyal/gtfs/validator/RouteTypeValidatorTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RouteTypeValidatorTest {
@@ -14,7 +15,7 @@ class RouteTypeValidatorTest {
     @Test
     void validateRouteType() {
         assertTrue(ROUTE_TYPE_VALIDATOR.isRouteTypeValid(3)); // Bus
-        assertTrue(ROUTE_TYPE_VALIDATOR.isRouteTypeValid(36)); // Invalid
+        assertFalse(ROUTE_TYPE_VALIDATOR.isRouteTypeValid(36)); // Invalid
         assertTrue(ROUTE_TYPE_VALIDATOR.isRouteTypeValid(101)); // High Speed Rail
     }
 }

--- a/src/test/java/com/conveyal/gtfs/validator/RouteTypeValidatorTest.java
+++ b/src/test/java/com/conveyal/gtfs/validator/RouteTypeValidatorTest.java
@@ -5,17 +5,16 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RouteTypeValidatorTest {
-    private static final List<Integer> ROUTE_TYPES = Lists.newArrayList(3, 101);
-    private static final RouteTypeValidator ROUTE_TYPE_VALIDATOR = new RouteTypeValidator(ROUTE_TYPES);
+    private static final List<Integer> TEST_ROUTE_TYPES = Lists.newArrayList(3, 101);
+    private static final RouteTypeValidator ROUTE_TYPE_VALIDATOR = new RouteTypeValidator(TEST_ROUTE_TYPES);
 
     @Test
     void validateRouteType() {
-        assertThat(ROUTE_TYPE_VALIDATOR.isRouteTypeValid(3), is(true)); // Bus
-        assertThat(ROUTE_TYPE_VALIDATOR.isRouteTypeValid(36), is(false)); // Invalid
-        assertThat(ROUTE_TYPE_VALIDATOR.isRouteTypeValid(101), is(true)); // High Speed Rail
+        assertTrue(ROUTE_TYPE_VALIDATOR.isRouteTypeValid(3)); // Bus
+        assertTrue(ROUTE_TYPE_VALIDATOR.isRouteTypeValid(36)); // Invalid
+        assertTrue(ROUTE_TYPE_VALIDATOR.isRouteTypeValid(101)); // High Speed Rail
     }
 }

--- a/src/test/java/com/conveyal/gtfs/validator/RouteTypeValidatorTest.java
+++ b/src/test/java/com/conveyal/gtfs/validator/RouteTypeValidatorTest.java
@@ -1,0 +1,21 @@
+package com.conveyal.gtfs.validator;
+
+import com.google.common.collect.Lists;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class RouteTypeValidatorTest {
+    private static final List<Integer> ROUTE_TYPES = Lists.newArrayList(3, 101);
+    private static final RouteTypeValidator ROUTE_TYPE_VALIDATOR = new RouteTypeValidator(ROUTE_TYPES);
+
+    @Test
+    void validateRouteType() {
+        assertThat(ROUTE_TYPE_VALIDATOR.isRouteTypeValid(3), is(true)); // Bus
+        assertThat(ROUTE_TYPE_VALIDATOR.isRouteTypeValid(36), is(false)); // Invalid
+        assertThat(ROUTE_TYPE_VALIDATOR.isRouteTypeValid(101), is(true)); // High Speed Rail
+    }
+}


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [na] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR adds a validator for the `route_type` field in the `routes` table based on preconfigured values.

Constraints: Implementers must explicitly construct a `RouteTypeValidator` by providing the configured route types that they want to support, and they must explicitly invoke the validator's `validate` method to perform route type validation (let me know if that is too constraining). Invalid route types result in medium-severity errors.

