### PR TITLE
Pattern reconciliation refactor

### DIFF
--- a/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
+++ b/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
@@ -888,32 +888,25 @@ public class JdbcTableWriter implements TableWriter {
 
         int cumulativeTravelTime = 0;
         for (PatternReconciliation.GenericStop genericStop : genericStops) {
-            PatternStop patternStop = null;
-            PatternLocation patternLocation = null;
-            if (genericStop.patternType == PatternReconciliation.PatternType.STOP) {
-                patternStop = patternStops
-                    .stream()
-                    .filter(ps -> ps.stop_id.equals(genericStop.referenceId))
-                    .findFirst()
-                    .orElse(null);
-            } else {
-                // Pattern type is location
-                patternLocation = patternLocations
-                    .stream()
-                    .filter(pl -> pl.location_id.equals(genericStop.referenceId))
-                    .findFirst()
-                    .orElse(null);
-            }
             // Update stop times linked to pattern stop/location and accumulate time.
             // Default travel and dwell time behave as "linked fields" for associated stop times. In other
             // words, frequency trips in the editor must match the pattern stop travel times.
-            int travelTimeForPatternHalts = 0;
-            if (patternStop != null) {
-                travelTimeForPatternHalts = updateStopTimesForPatternStop(patternStop, cumulativeTravelTime, null);
-            } else if (patternLocation != null) {
-                travelTimeForPatternHalts = updateStopTimesForPatternLocation(patternLocation, cumulativeTravelTime, null);
+            if (genericStop.patternType == PatternReconciliation.PatternType.STOP) {
+                PatternStop patternStop = patternStops
+                    .stream()
+                    .filter(ps -> ps.stop_id.equals(genericStop.referenceId))
+                    .findFirst()
+                    .get();
+                cumulativeTravelTime += updateStopTimesForPatternStop(patternStop, cumulativeTravelTime, null);
+            } else {
+                // Pattern type is location
+                PatternLocation patternLocation = patternLocations
+                    .stream()
+                    .filter(pl -> pl.location_id.equals(genericStop.referenceId))
+                    .findFirst()
+                    .get();
+                cumulativeTravelTime += updateStopTimesForPatternLocation(patternLocation, cumulativeTravelTime, null);
             }
-            cumulativeTravelTime += travelTimeForPatternHalts;
         }
     }
 

--- a/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
+++ b/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
@@ -630,7 +630,7 @@ public class JdbcTableWriter implements TableWriter {
         }
         boolean isPatternTable = Table.PATTERN_STOP.name.equals(subTable.name) || Table.PATTERN_LOCATION.name.equals(subTable.name);
         if (isPatternTable) {
-            reconciliation.stagePatternReconciliation(mapper, subTable, subEntities, keyValue);
+            reconciliation.stage(mapper, subTable, subEntities, keyValue);
         }
         if (!isCreatingNewEntity) {
             // If not creating a new entity, we will delete the child entities (e.g., shape points or pattern stops) and

--- a/src/main/java/com/conveyal/gtfs/model/StopTime.java
+++ b/src/main/java/com/conveyal/gtfs/model/StopTime.java
@@ -82,10 +82,10 @@ public class StopTime extends Entity implements Cloneable, Serializable {
         statement.setString(oneBasedIndex++, drop_off_booking_rule_id);
         setIntParameter(statement, oneBasedIndex++, start_pickup_dropoff_window);
         setIntParameter(statement, oneBasedIndex++, end_pickup_dropoff_window);
-        statement.setDouble(oneBasedIndex++, mean_duration_factor);
-        statement.setDouble(oneBasedIndex++, mean_duration_offset);
-        statement.setDouble(oneBasedIndex++, safe_duration_factor);
-        statement.setDouble(oneBasedIndex++, safe_duration_offset);
+        setDoubleParameter(statement, oneBasedIndex++, mean_duration_factor);
+        setDoubleParameter(statement, oneBasedIndex++, mean_duration_offset);
+        setDoubleParameter(statement, oneBasedIndex++, safe_duration_factor);
+        setDoubleParameter(statement, oneBasedIndex, safe_duration_offset);
     }
 
     public static class Loader extends Entity.Loader<StopTime> {

--- a/src/main/java/com/conveyal/gtfs/util/json/JsonManager.java
+++ b/src/main/java/com/conveyal/gtfs/util/json/JsonManager.java
@@ -1,20 +1,22 @@
 package com.conveyal.gtfs.util.json;
 
-import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 
 import java.awt.geom.Rectangle2D;
 import java.io.IOException;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -77,16 +79,6 @@ public class JsonManager<T> {
     }
 
     /**
-     * Convert an object to its JSON representation
-     * @param o the object to convert
-     * @return the JSON string
-     * @throws JsonProcessingException
-     */
-    /*public String write (T o) throws JsonProcessingException {
-        return writer.writeValueAsString(o);
-    }*/
-
-    /**
      * Convert a collection of objects to their JSON representation.
      * @param c the collection
      * @return A JsonNode representing the collection
@@ -100,15 +92,31 @@ public class JsonManager<T> {
         return writer.writeValueAsString(map);
     }
 
-    public T read (String s) throws JsonParseException, JsonMappingException, IOException {
+    public T read (String s) throws IOException {
         return mapper.readValue(s, theClass);
     }
 
-    public T read (JsonParser p) throws JsonParseException, JsonMappingException, IOException {
+    public T read (JsonParser p) throws IOException {
         return mapper.readValue(p, theClass);
     }
 
     public T read(JsonNode asJson) {
         return mapper.convertValue(asJson, theClass);
+    }
+
+    public static <T> List<T> read(ObjectMapper mapper, ArrayNode subEntities, Class<T> target)
+        throws JsonProcessingException {
+
+        List<T> list = new ArrayList<>();
+        for (JsonNode node : subEntities) {
+            ObjectNode objectNode = (ObjectNode) node;
+            if (!objectNode.get("id").isNumber()) {
+                // Set ID to zero. ID is ignored entirely here.
+                objectNode.put("id", 0);
+            }
+            // Accumulate new objects from JSON.
+            list.add(mapper.readValue(objectNode.toString(), target));
+        }
+        return list;
     }
 }

--- a/src/main/java/com/conveyal/gtfs/util/json/JsonManager.java
+++ b/src/main/java/com/conveyal/gtfs/util/json/JsonManager.java
@@ -115,7 +115,7 @@ public class JsonManager<T> {
                 objectNode.put("id", 0);
             }
             // Accumulate new objects from JSON.
-            list.add(mapper.readValue(objectNode.toString(), target));
+            list.add(mapper.treeToValue(objectNode, target));
         }
         return list;
     }

--- a/src/test/java/com/conveyal/gtfs/dto/PatternLocationDTO.java
+++ b/src/test/java/com/conveyal/gtfs/dto/PatternLocationDTO.java
@@ -41,4 +41,18 @@ public class PatternLocationDTO {
         stop_sequence = stopSequence;
     }
 
+    public PatternLocationDTO (
+        String patternId,
+        String locationId,
+        int stopSequence,
+        int flexDefaultTravelTime,
+        int flexDefaultZoneTime
+    ) {
+        pattern_id = patternId;
+        location_id = locationId;
+        stop_sequence = stopSequence;
+        flex_default_travel_time = flexDefaultTravelTime;
+        flex_default_zone_time = flexDefaultZoneTime;
+    }
+
 }

--- a/src/test/java/com/conveyal/gtfs/dto/PatternStopDTO.java
+++ b/src/test/java/com/conveyal/gtfs/dto/PatternStopDTO.java
@@ -26,4 +26,11 @@ public class PatternStopDTO {
         stop_id = stopId;
         stop_sequence = stopSequence;
     }
+    public PatternStopDTO (String patternId, String stopId, int stopSequence, int defaultTravelTime, int defaultDwellTime) {
+        pattern_id = patternId;
+        stop_id = stopId;
+        stop_sequence = stopSequence;
+        default_travel_time = defaultTravelTime;
+        default_dwell_time = defaultDwellTime;
+    }
 }

--- a/src/test/java/com/conveyal/gtfs/loader/JDBCTableWriterTest.java
+++ b/src/test/java/com/conveyal/gtfs/loader/JDBCTableWriterTest.java
@@ -74,7 +74,7 @@ public class JDBCTableWriterTest {
     private static LocationDTO locationTwo;
     private static LocationDTO locationThree;
 
-    private static JdbcTableWriter createTestTableWriter (Table table) throws InvalidNamespaceException {
+    private static JdbcTableWriter createTestTableWriter(Table table) throws InvalidNamespaceException {
         return new JdbcTableWriter(table, testDataSource, testNamespace);
     }
 
@@ -310,9 +310,9 @@ public class JDBCTableWriterTest {
         // covert object to json and save it
         JdbcTableWriter updateTableWriter = createTestTableWriter(fareTable);
         String updateOutput = updateTableWriter.update(
-                createdFare.id,
-                mapper.writeValueAsString(createdFare),
-                true
+            createdFare.id,
+            mapper.writeValueAsString(createdFare),
+            true
         );
         LOG.info("update {} output:", fareTable.name);
         LOG.info(updateOutput);
@@ -333,8 +333,8 @@ public class JDBCTableWriterTest {
         // try to delete record
         JdbcTableWriter deleteTableWriter = createTestTableWriter(fareTable);
         int deleteOutput = deleteTableWriter.delete(
-                createdFare.id,
-                true
+            createdFare.id,
+            true
         );
         LOG.info("deleted {} records from {}", deleteOutput, fareTable.name);
 
@@ -369,9 +369,9 @@ public class JDBCTableWriterTest {
         // convert object to json and save it
         JdbcTableWriter updateTableWriter = createTestTableWriter(routeTable);
         String updateOutput = updateTableWriter.update(
-                createdRoute.id,
-                mapper.writeValueAsString(createdRoute),
-                true
+            createdRoute.id,
+            mapper.writeValueAsString(createdRoute),
+            true
         );
         LOG.info("update {} output:", routeTable.name);
         LOG.info(updateOutput);
@@ -394,8 +394,8 @@ public class JDBCTableWriterTest {
         // try to delete record
         JdbcTableWriter deleteTableWriter = createTestTableWriter(routeTable);
         int deleteOutput = deleteTableWriter.delete(
-                createdRoute.id,
-                true
+            createdRoute.id,
+            true
         );
         LOG.info("deleted {} records from {}", deleteOutput, routeTable.name);
 
@@ -426,9 +426,9 @@ public class JDBCTableWriterTest {
         // convert object to json and save it
         JdbcTableWriter updateTableWriter = createTestTableWriter(bookingRuleTable);
         String updateOutput = updateTableWriter.update(
-                createdBookingRule.id,
-                mapper.writeValueAsString(createdBookingRule),
-                true
+            createdBookingRule.id,
+            mapper.writeValueAsString(createdBookingRule),
+            true
         );
         LOG.info("update {} output:", bookingRuleTable.name);
         LOG.info(updateOutput);
@@ -450,8 +450,8 @@ public class JDBCTableWriterTest {
         // try to delete record
         JdbcTableWriter deleteTableWriter = createTestTableWriter(bookingRuleTable);
         int deleteOutput = deleteTableWriter.delete(
-                createdBookingRule.id,
-                true
+            createdBookingRule.id,
+            true
         );
         LOG.info("deleted {} records from {}", deleteOutput, bookingRuleTable.name);
 
@@ -482,8 +482,8 @@ public class JDBCTableWriterTest {
         JdbcTableWriter updateTableWriter = createTestTableWriter(locationGroupsTable);
         String updateOutput = updateTableWriter.update(
             createdLocationGroup.id,
-                mapper.writeValueAsString(createdLocationGroup),
-                true
+            mapper.writeValueAsString(createdLocationGroup),
+            true
         );
         LOG.info("update {} output:", locationGroupsTable.name);
         LOG.info(updateOutput);
@@ -506,7 +506,7 @@ public class JDBCTableWriterTest {
         JdbcTableWriter deleteTableWriter = createTestTableWriter(locationGroupsTable);
         int deleteOutput = deleteTableWriter.delete(
             createdLocationGroup.id,
-                true
+            true
         );
         LOG.info("deleted {} records from {}", deleteOutput, locationGroupsTable.name);
 
@@ -541,9 +541,9 @@ public class JDBCTableWriterTest {
         // convert object to json and save it
         JdbcTableWriter updateTableWriter = createTestTableWriter(Table.LOCATIONS);
         String updateOutput = updateTableWriter.update(
-                createdLocation.id,
-                mapper.writeValueAsString(createdLocation),
-                true
+            createdLocation.id,
+            mapper.writeValueAsString(createdLocation),
+            true
         );
         LOG.info("update {} output:", Table.LOCATIONS.name);
         LOG.info(updateOutput);
@@ -605,8 +605,8 @@ public class JDBCTableWriterTest {
         JdbcTableWriter updateTableWriter = createTestTableWriter(locationShapeTable);
         String updateOutput = updateTableWriter.update(
             createdLocationShape.id,
-                mapper.writeValueAsString(createdLocationShape),
-                true
+            mapper.writeValueAsString(createdLocationShape),
+            true
         );
         LOG.info("update {} output:", locationShapeTable.name);
         LOG.info(updateOutput);
@@ -625,7 +625,7 @@ public class JDBCTableWriterTest {
         JdbcTableWriter deleteTableWriter = createTestTableWriter(locationShapeTable);
         int deleteOutput = deleteTableWriter.delete(
             createdLocationShape.id,
-                true
+            true
         );
         LOG.info("deleted {} records from {}", deleteOutput, locationShapeTable.name);
 
@@ -688,7 +688,7 @@ public class JDBCTableWriterTest {
         JdbcTableWriter deleteTableWriter = createTestTableWriter(stopTimesTable);
         int deleteOutput = deleteTableWriter.delete(
             createdStopTime.id,
-                true
+            true
         );
         LOG.info("deleted {} records from {}", deleteOutput, stopTimesTable.name);
 
@@ -714,7 +714,7 @@ public class JDBCTableWriterTest {
         TableWriter<ScheduleException> createTableWriter = createTestTableWriter(scheduleExceptionTable);
         String scheduleExceptionOutput = createTableWriter.create(mapper.writeValueAsString(exceptionInput), true);
         ScheduleExceptionDTO scheduleException = mapper.readValue(scheduleExceptionOutput,
-                                                                         scheduleExceptionDTOClass);
+            scheduleExceptionDTOClass);
         // Make sure saved data matches expected data.
         assertThat(scheduleException.removed_service[0], equalTo(simpleServiceId));
         ResultSet resultSet = getResultSetForId(scheduleException.id, scheduleExceptionTable, "removed_service");
@@ -763,7 +763,7 @@ public class JDBCTableWriterTest {
      */
     @Test
     public void shouldUpdateStopTimeOnPatternStopUpdate() throws IOException, SQLException, InvalidNamespaceException {
-        final String[] STOP_TIMES_LINKED_FIELDS = new String[] {
+        final String[] STOP_TIMES_LINKED_FIELDS = new String[]{
             "shape_dist_traveled",
             "timepoint",
             "drop_off_type",
@@ -1017,12 +1017,12 @@ public class JDBCTableWriterTest {
         };
         patternStops[1].default_travel_time = initialTravelTime;
         PatternDTO pattern = createRouteAndPattern(newUUID(),
-                                                   patternId,
-                                                   "Pattern A",
-                                                   null,
-                                                   new ShapePointDTO[]{},
-                                                   patternStops,
-                                                   0);
+            patternId,
+            "Pattern A",
+            null,
+            new ShapePointDTO[]{},
+            patternStops,
+            0);
         // Create trip with travel times that match pattern stops.
         TripDTO tripInput = constructTimetableTrip(pattern.pattern_id, pattern.route_id, startTime, initialTravelTime);
         JdbcTableWriter createTripWriter = createTestTableWriter(tripsTable);
@@ -1040,9 +1040,9 @@ public class JDBCTableWriterTest {
         updateTripWriter.normalizeStopTimesForPattern(pattern.id, 0);
         // Read pattern stops from database and check that the arrivals/departures have been updated.
         JDBCTableReader<StopTime> stopTimesTable = new JDBCTableReader(Table.STOP_TIMES,
-                                                                       testDataSource,
-                                                                       testNamespace + ".",
-                                                                       EntityPopulator.STOP_TIME);
+            testDataSource,
+            testNamespace + ".",
+            EntityPopulator.STOP_TIME);
         int index = 0;
         for (StopTime stopTime : stopTimesTable.getOrdered(createdTrip.trip_id)) {
             LOG.info("stop times i={} arrival={} departure={}", index, stopTime.arrival_time, stopTime.departure_time);
@@ -1088,10 +1088,10 @@ public class JDBCTableWriterTest {
         return Stream.of(
             // Add a new stop to the end.
             new PatternArguments(
-                new PatternLocationDTO[] {
+                new PatternLocationDTO[]{
                     new PatternLocationDTO(patternId, locationOne.location_id, 0, 10, 10)
                 },
-                new PatternStopDTO[] {
+                new PatternStopDTO[]{
                     new PatternStopDTO(patternId, stopOne.stop_id, 1, 10, 1),
                     new PatternStopDTO(patternId, stopTwo.stop_id, 2, 10, 1)
                 },
@@ -1104,10 +1104,10 @@ public class JDBCTableWriterTest {
             ),
             // Delete stop from the middle.
             new PatternArguments(
-                new PatternLocationDTO[] {
+                new PatternLocationDTO[]{
                     new PatternLocationDTO(patternId, locationOne.location_id, 0, 20, 20)
                 },
-                new PatternStopDTO[] {
+                new PatternStopDTO[]{
                     new PatternStopDTO(patternId, stopTwo.stop_id, 1, 12, 1)
                 },
                 ImmutableMap.of(
@@ -1118,10 +1118,10 @@ public class JDBCTableWriterTest {
             ),
             // Change the order of the location and stop.
             new PatternArguments(
-                new PatternLocationDTO[] {
+                new PatternLocationDTO[]{
                     new PatternLocationDTO(patternId, locationOne.location_id, 1, 30, 30)
                 },
-                new PatternStopDTO[] {
+                new PatternStopDTO[]{
                     new PatternStopDTO(patternId, stopTwo.stop_id, 0, 11, 1)
                 },
                 ImmutableMap.of(
@@ -1132,11 +1132,11 @@ public class JDBCTableWriterTest {
             ),
             // Add a new location between the location and stop.
             new PatternArguments(
-                new PatternLocationDTO[] {
+                new PatternLocationDTO[]{
                     new PatternLocationDTO(patternId, locationOne.location_id, 2, 40, 40),
                     new PatternLocationDTO(patternId, locationTwo.location_id, 1, 40, 40)
                 },
-                new PatternStopDTO[] {
+                new PatternStopDTO[]{
                     new PatternStopDTO(patternId, stopTwo.stop_id, 0, 12, 5)
                 },
                 ImmutableMap.of(
@@ -1148,11 +1148,11 @@ public class JDBCTableWriterTest {
             ),
             // Add a new stop at the end.
             new PatternArguments(
-                new PatternLocationDTO[] {
+                new PatternLocationDTO[]{
                     new PatternLocationDTO(patternId, locationOne.location_id, 2, 50, 50),
                     new PatternLocationDTO(patternId, locationTwo.location_id, 1, 50, 50)
                 },
-                new PatternStopDTO[] {
+                new PatternStopDTO[]{
                     new PatternStopDTO(patternId, stopTwo.stop_id, 0, 14, 3),
                     new PatternStopDTO(patternId, stopOne.stop_id, 3, 14, 3)
                 },
@@ -1166,10 +1166,10 @@ public class JDBCTableWriterTest {
             ),
             // Delete the first location.
             new PatternArguments(
-                new PatternLocationDTO[] {
+                new PatternLocationDTO[]{
                     new PatternLocationDTO(patternId, locationOne.location_id, 1, 60, 60)
                 },
-                new PatternStopDTO[] {
+                new PatternStopDTO[]{
                     new PatternStopDTO(patternId, stopTwo.stop_id, 0, 23, 1),
                     new PatternStopDTO(patternId, stopOne.stop_id, 2, 23, 1)
                 },
@@ -1182,11 +1182,11 @@ public class JDBCTableWriterTest {
             ),
             // Add a stop and location to the end.
             new PatternArguments(
-                new PatternLocationDTO[] {
+                new PatternLocationDTO[]{
                     new PatternLocationDTO(patternId, locationOne.location_id, 1, 70, 70),
                     new PatternLocationDTO(patternId, locationThree.location_id, 3, 70, 70)
                 },
-                new PatternStopDTO[] {
+                new PatternStopDTO[]{
                     new PatternStopDTO(patternId, stopTwo.stop_id, 0, 13, 6),
                     new PatternStopDTO(patternId, stopOne.stop_id, 2, 13, 6),
                     new PatternStopDTO(patternId, stopThree.stop_id, 4, 13, 6)
@@ -1249,33 +1249,36 @@ public class JDBCTableWriterTest {
         int end,
         PatternReconciliation.PatternType patternType
     ) throws SQLException {
-        String sql = String.format(
-            "select * from %s.%s where trip_id='%s' and stop_id='%s' and stop_sequence=%s",
-            testNamespace,
-            Table.STOP_TIMES.name,
-            tripId,
-            stopId,
-            stopSequence
-        );
-        LOG.info(sql);
-        ResultSet stopTimesResultSet = connection.createStatement().executeQuery(sql);
-        if (!stopTimesResultSet.isBeforeFirst()) {
-            throw new SQLException(
+        try (
+            ResultSet stopTimesResultSet = connection.createStatement().executeQuery(
                 String.format(
-                    "No stop time matching trip_id: %s, stop_id: %s and stop_sequence: %s.",
+                    "select * from %s.%s where trip_id='%s' and stop_id='%s' and stop_sequence=%s",
+                    testNamespace,
+                    Table.STOP_TIMES.name,
                     tripId,
                     stopId,
                     stopSequence
                 )
-            );
-        }
-        while (stopTimesResultSet.next()) {
-            if (patternType == PatternReconciliation.PatternType.STOP) {
-                assertResultValue(stopTimesResultSet, "arrival_time", equalTo(start));
-                assertResultValue(stopTimesResultSet, "departure_time", equalTo(end));
-            } else {
-                assertResultValue(stopTimesResultSet, "start_pickup_dropoff_window", equalTo(start));
-                assertResultValue(stopTimesResultSet, "end_pickup_dropoff_window", equalTo(end));
+            )
+        ) {
+            if (!stopTimesResultSet.isBeforeFirst()) {
+                throw new SQLException(
+                    String.format(
+                        "No stop time matching trip_id: %s, stop_id: %s and stop_sequence: %s.",
+                        tripId,
+                        stopId,
+                        stopSequence
+                    )
+                );
+            }
+            while (stopTimesResultSet.next()) {
+                if (patternType == PatternReconciliation.PatternType.STOP) {
+                    assertResultValue(stopTimesResultSet, "arrival_time", equalTo(start));
+                    assertResultValue(stopTimesResultSet, "departure_time", equalTo(end));
+                } else {
+                    assertResultValue(stopTimesResultSet, "start_pickup_dropoff_window", equalTo(start));
+                    assertResultValue(stopTimesResultSet, "end_pickup_dropoff_window", equalTo(end));
+                }
             }
         }
     }
@@ -1444,7 +1447,7 @@ public class JDBCTableWriterTest {
         input.use_frequency = useFrequency;
         input.shape_id = shapeId;
         input.shapes = shapes;
-        input.pattern_stops = new PatternStopDTO[] {};
+        input.pattern_stops = new PatternStopDTO[]{};
         input.pattern_locations = patternLocations;
         // Write the pattern to the database
         JdbcTableWriter createPatternWriter = createTestTableWriter(Table.PATTERNS);
@@ -1589,7 +1592,7 @@ public class JDBCTableWriterTest {
         location.stop_desc = "Templeboy to Ballisodare Door-to-door pickup area";
         location.zone_id = "1";
         location.stop_url = new URL("https://www.Teststopsite.com");
-        location.location_shapes = new LocationShapeDTO[] {
+        location.location_shapes = new LocationShapeDTO[]{
             locationShape
         };
 

--- a/src/test/java/com/conveyal/gtfs/loader/JDBCTableWriterTest.java
+++ b/src/test/java/com/conveyal/gtfs/loader/JDBCTableWriterTest.java
@@ -1,8 +1,26 @@
 package com.conveyal.gtfs.loader;
 
 import com.conveyal.gtfs.TestUtils;
-import com.conveyal.gtfs.dto.*;
-import com.conveyal.gtfs.model.*;
+import com.conveyal.gtfs.dto.BookingRuleDTO;
+import com.conveyal.gtfs.dto.CalendarDTO;
+import com.conveyal.gtfs.dto.FareDTO;
+import com.conveyal.gtfs.dto.FareRuleDTO;
+import com.conveyal.gtfs.dto.FeedInfoDTO;
+import com.conveyal.gtfs.dto.FrequencyDTO;
+import com.conveyal.gtfs.dto.LocationDTO;
+import com.conveyal.gtfs.dto.LocationGroupDTO;
+import com.conveyal.gtfs.dto.LocationShapeDTO;
+import com.conveyal.gtfs.dto.PatternDTO;
+import com.conveyal.gtfs.dto.PatternLocationDTO;
+import com.conveyal.gtfs.dto.PatternStopDTO;
+import com.conveyal.gtfs.dto.RouteDTO;
+import com.conveyal.gtfs.dto.ScheduleExceptionDTO;
+import com.conveyal.gtfs.dto.ShapePointDTO;
+import com.conveyal.gtfs.dto.StopDTO;
+import com.conveyal.gtfs.dto.StopTimeDTO;
+import com.conveyal.gtfs.dto.TripDTO;
+import com.conveyal.gtfs.model.ScheduleException;
+import com.conveyal.gtfs.model.StopTime;
 import com.conveyal.gtfs.util.InvalidNamespaceException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
@@ -127,17 +145,17 @@ public class JDBCTableWriterTest {
             patternId,
             "pattern name",
             null,
-            new ShapePointDTO[]{},
-            new PatternLocationDTO[]{
+            new ShapePointDTO[] {},
+            new PatternLocationDTO[] {
                 new PatternLocationDTO(patternId, locationOne.location_id, 0)
             },
-            new PatternStopDTO[]{
+            new PatternStopDTO[] {
                 new PatternStopDTO(patternId, stopOne.stop_id, 1)
             },
             1
         );
 
-        StopTimeDTO[] stopTimes = new StopTimeDTO[]{
+        StopTimeDTO[] stopTimes = new StopTimeDTO[] {
             new StopTimeDTO(locationOne.location_id, 0, 0, 0),
             new StopTimeDTO(stopOne.stop_id, 0, 0, 1)
         };
@@ -273,7 +291,7 @@ public class JDBCTableWriterTest {
         fareRuleInput.contains_id = "any";
         fareRuleInput.origin_id = "value";
         fareRuleInput.destination_id = "permitted";
-        fareInput.fare_rules = new FareRuleDTO[]{fareRuleInput};
+        fareInput.fare_rules = new FareRuleDTO[] {fareRuleInput};
 
         // convert object to json and save it
         JdbcTableWriter createTableWriter = createTestTableWriter(fareTable);
@@ -708,8 +726,8 @@ public class JDBCTableWriterTest {
         ScheduleExceptionDTO exceptionInput = new ScheduleExceptionDTO();
         exceptionInput.name = "Halloween";
         exceptionInput.exemplar = 9; // Add, swap, or remove type
-        exceptionInput.removed_service = new String[]{simpleServiceId};
-        String[] halloweenDate = new String[]{"20191031"};
+        exceptionInput.removed_service = new String[] {simpleServiceId};
+        String[] halloweenDate = new String[] {"20191031"};
         exceptionInput.dates = halloweenDate;
         TableWriter<ScheduleException> createTableWriter = createTestTableWriter(scheduleExceptionTable);
         String scheduleExceptionOutput = createTableWriter.create(mapper.writeValueAsString(exceptionInput), true);
@@ -725,7 +743,7 @@ public class JDBCTableWriterTest {
             }
         }
         // try to update record
-        String[] updatedDates = new String[]{"20191031", "20201031"};
+        String[] updatedDates = new String[] {"20191031", "20201031"};
         scheduleException.dates = updatedDates;
         // covert object to json and save it
         JdbcTableWriter updateTableWriter = createTestTableWriter(scheduleExceptionTable);
@@ -763,7 +781,7 @@ public class JDBCTableWriterTest {
      */
     @Test
     public void shouldUpdateStopTimeOnPatternStopUpdate() throws IOException, SQLException, InvalidNamespaceException {
-        final String[] STOP_TIMES_LINKED_FIELDS = new String[]{
+        final String[] STOP_TIMES_LINKED_FIELDS = new String[] {
             "shape_dist_traveled",
             "timepoint",
             "drop_off_type",
@@ -779,8 +797,8 @@ public class JDBCTableWriterTest {
             patternId,
             "pattern name",
             null,
-            new ShapePointDTO[]{},
-            new PatternStopDTO[]{
+            new ShapePointDTO[] {},
+            new PatternStopDTO[] {
                 new PatternStopDTO(patternId, firstStopId, 0),
                 new PatternStopDTO(patternId, lastStopId, 1)
             },
@@ -905,11 +923,11 @@ public class JDBCTableWriterTest {
     @Test
     public void shouldChangeShapeIdOnPatternUpdate() throws IOException, SQLException, InvalidNamespaceException {
         String patternId = "10";
-        ShapePointDTO[] shapes = new ShapePointDTO[]{
+        ShapePointDTO[] shapes = new ShapePointDTO[] {
             new ShapePointDTO(2, 0.0, sharedShapeId, firstStopLat, firstStopLon, 0),
             new ShapePointDTO(2, 150.0, sharedShapeId, lastStopLat, lastStopLon, 1)
         };
-        PatternStopDTO[] patternStops = new PatternStopDTO[]{
+        PatternStopDTO[] patternStops = new PatternStopDTO[] {
             new PatternStopDTO(patternId, firstStopId, 0),
             new PatternStopDTO(patternId, lastStopId, 1)
         };
@@ -957,7 +975,7 @@ public class JDBCTableWriterTest {
         // Update pattern with pattern stops, set to use frequencies, and TODO shape points
         JdbcTableWriter patternUpdater = createTestTableWriter(Table.PATTERNS);
         simplePattern.use_frequency = 1;
-        simplePattern.pattern_stops = new PatternStopDTO[]{
+        simplePattern.pattern_stops = new PatternStopDTO[] {
             new PatternStopDTO(simplePattern.pattern_id, firstStopId, 0),
             new PatternStopDTO(simplePattern.pattern_id, lastStopId, 1)
         };
@@ -1011,7 +1029,7 @@ public class JDBCTableWriterTest {
         int initialTravelTime = 60; // one minute
         int startTime = 6 * 60 * 60; // 6AM
         String patternId = "123456";
-        PatternStopDTO[] patternStops = new PatternStopDTO[]{
+        PatternStopDTO[] patternStops = new PatternStopDTO[] {
             new PatternStopDTO(patternId, firstStopId, 0),
             new PatternStopDTO(patternId, lastStopId, 1)
         };
@@ -1020,7 +1038,7 @@ public class JDBCTableWriterTest {
             patternId,
             "Pattern A",
             null,
-            new ShapePointDTO[]{},
+            new ShapePointDTO[] {},
             patternStops,
             0);
         // Create trip with travel times that match pattern stops.
@@ -1088,10 +1106,10 @@ public class JDBCTableWriterTest {
         return Stream.of(
             // Add a new stop to the end.
             new PatternArguments(
-                new PatternLocationDTO[]{
+                new PatternLocationDTO[] {
                     new PatternLocationDTO(patternId, locationOne.location_id, 0, 10, 10)
                 },
-                new PatternStopDTO[]{
+                new PatternStopDTO[] {
                     new PatternStopDTO(patternId, stopOne.stop_id, 1, 10, 1),
                     new PatternStopDTO(patternId, stopTwo.stop_id, 2, 10, 1)
                 },
@@ -1104,10 +1122,10 @@ public class JDBCTableWriterTest {
             ),
             // Delete stop from the middle.
             new PatternArguments(
-                new PatternLocationDTO[]{
+                new PatternLocationDTO[] {
                     new PatternLocationDTO(patternId, locationOne.location_id, 0, 20, 20)
                 },
-                new PatternStopDTO[]{
+                new PatternStopDTO[] {
                     new PatternStopDTO(patternId, stopTwo.stop_id, 1, 12, 1)
                 },
                 ImmutableMap.of(
@@ -1118,10 +1136,10 @@ public class JDBCTableWriterTest {
             ),
             // Change the order of the location and stop.
             new PatternArguments(
-                new PatternLocationDTO[]{
+                new PatternLocationDTO[] {
                     new PatternLocationDTO(patternId, locationOne.location_id, 1, 30, 30)
                 },
-                new PatternStopDTO[]{
+                new PatternStopDTO[] {
                     new PatternStopDTO(patternId, stopTwo.stop_id, 0, 11, 1)
                 },
                 ImmutableMap.of(
@@ -1132,11 +1150,11 @@ public class JDBCTableWriterTest {
             ),
             // Add a new location between the location and stop.
             new PatternArguments(
-                new PatternLocationDTO[]{
+                new PatternLocationDTO[] {
                     new PatternLocationDTO(patternId, locationOne.location_id, 2, 40, 40),
                     new PatternLocationDTO(patternId, locationTwo.location_id, 1, 40, 40)
                 },
-                new PatternStopDTO[]{
+                new PatternStopDTO[] {
                     new PatternStopDTO(patternId, stopTwo.stop_id, 0, 12, 5)
                 },
                 ImmutableMap.of(
@@ -1148,11 +1166,11 @@ public class JDBCTableWriterTest {
             ),
             // Add a new stop at the end.
             new PatternArguments(
-                new PatternLocationDTO[]{
+                new PatternLocationDTO[] {
                     new PatternLocationDTO(patternId, locationOne.location_id, 2, 50, 50),
                     new PatternLocationDTO(patternId, locationTwo.location_id, 1, 50, 50)
                 },
-                new PatternStopDTO[]{
+                new PatternStopDTO[] {
                     new PatternStopDTO(patternId, stopTwo.stop_id, 0, 14, 3),
                     new PatternStopDTO(patternId, stopOne.stop_id, 3, 14, 3)
                 },
@@ -1166,10 +1184,10 @@ public class JDBCTableWriterTest {
             ),
             // Delete the first location.
             new PatternArguments(
-                new PatternLocationDTO[]{
+                new PatternLocationDTO[] {
                     new PatternLocationDTO(patternId, locationOne.location_id, 1, 60, 60)
                 },
-                new PatternStopDTO[]{
+                new PatternStopDTO[] {
                     new PatternStopDTO(patternId, stopTwo.stop_id, 0, 23, 1),
                     new PatternStopDTO(patternId, stopOne.stop_id, 2, 23, 1)
                 },
@@ -1182,11 +1200,11 @@ public class JDBCTableWriterTest {
             ),
             // Add a stop and location to the end.
             new PatternArguments(
-                new PatternLocationDTO[]{
+                new PatternLocationDTO[] {
                     new PatternLocationDTO(patternId, locationOne.location_id, 1, 70, 70),
                     new PatternLocationDTO(patternId, locationThree.location_id, 3, 70, 70)
                 },
-                new PatternStopDTO[]{
+                new PatternStopDTO[] {
                     new PatternStopDTO(patternId, stopTwo.stop_id, 0, 13, 6),
                     new PatternStopDTO(patternId, stopOne.stop_id, 2, 13, 6),
                     new PatternStopDTO(patternId, stopThree.stop_id, 4, 13, 6)
@@ -1340,7 +1358,7 @@ public class JDBCTableWriterTest {
         tripInput.pattern_id = patternId;
         tripInput.route_id = routeId;
         tripInput.service_id = simpleServiceId;
-        tripInput.stop_times = new StopTimeDTO[]{
+        tripInput.stop_times = new StopTimeDTO[] {
             new StopTimeDTO(firstStopId, 0, 0, 0),
             new StopTimeDTO(lastStopId, 60, 60, 1)
         };
@@ -1348,7 +1366,7 @@ public class JDBCTableWriterTest {
         frequency.start_time = startTime;
         frequency.end_time = 9 * 60 * 60;
         frequency.headway_secs = 15 * 60;
-        tripInput.frequencies = new FrequencyDTO[]{frequency};
+        tripInput.frequencies = new FrequencyDTO[] {frequency};
         return tripInput;
     }
 
@@ -1370,7 +1388,7 @@ public class JDBCTableWriterTest {
         int startTime,
         int travelTime
     ) {
-        StopTimeDTO[] stopTimes = new StopTimeDTO[]{
+        StopTimeDTO[] stopTimes = new StopTimeDTO[] {
             new StopTimeDTO(firstStopId, startTime, startTime, 0),
             new StopTimeDTO(lastStopId, startTime + travelTime, startTime + travelTime, 1)
         };
@@ -1390,7 +1408,7 @@ public class JDBCTableWriterTest {
         tripInput.route_id = routeId;
         tripInput.service_id = simpleServiceId;
         tripInput.stop_times = stopTimes;
-        tripInput.frequencies = new FrequencyDTO[]{};
+        tripInput.frequencies = new FrequencyDTO[] {};
         return tripInput;
     }
 
@@ -1447,7 +1465,7 @@ public class JDBCTableWriterTest {
         input.use_frequency = useFrequency;
         input.shape_id = shapeId;
         input.shapes = shapes;
-        input.pattern_stops = new PatternStopDTO[]{};
+        input.pattern_stops = new PatternStopDTO[] {};
         input.pattern_locations = patternLocations;
         // Write the pattern to the database
         JdbcTableWriter createPatternWriter = createTestTableWriter(Table.PATTERNS);
@@ -1495,7 +1513,7 @@ public class JDBCTableWriterTest {
      * Creates a pattern by first creating a route and then a pattern for that route.
      */
     private static PatternDTO createRouteAndSimplePattern(String routeId, String patternId, String name) throws InvalidNamespaceException, SQLException, IOException {
-        return createRouteAndPattern(routeId, patternId, name, null, new ShapePointDTO[]{}, new PatternStopDTO[]{}, 0);
+        return createRouteAndPattern(routeId, patternId, name, null, new ShapePointDTO[] {}, new PatternStopDTO[] {}, 0);
     }
 
     /**
@@ -1592,7 +1610,7 @@ public class JDBCTableWriterTest {
         location.stop_desc = "Templeboy to Ballisodare Door-to-door pickup area";
         location.zone_id = "1";
         location.stop_url = new URL("https://www.Teststopsite.com");
-        location.location_shapes = new LocationShapeDTO[]{
+        location.location_shapes = new LocationShapeDTO[] {
             locationShape
         };
 

--- a/src/test/java/com/conveyal/gtfs/loader/JDBCTableWriterTest.java
+++ b/src/test/java/com/conveyal/gtfs/loader/JDBCTableWriterTest.java
@@ -86,7 +86,6 @@ public class JDBCTableWriterTest {
         testDataSource = TestUtils.createTestDataSource(dbConnectionUrl);
         connection = testDataSource.getConnection();
         LOG.info("creating feeds table because it isn't automatically generated unless you import a feed");
-        Connection connection = testDataSource.getConnection();
         connection.createStatement().execute(JdbcGtfsLoader.getCreateFeedRegistrySQL());
         connection.commit();
         LOG.info("feeds table created");
@@ -150,7 +149,8 @@ public class JDBCTableWriterTest {
     }
 
     @AfterAll
-    public static void tearDownClass() {
+    public static void tearDownClass() throws SQLException {
+        connection.close();
         TestUtils.dropDB(testDBName);
     }
 
@@ -1084,76 +1084,77 @@ public class JDBCTableWriterTest {
      * see {@link JDBCTableWriterTest#patternReconciliationSetUp()} in the order defined.
      */
     private static Stream<PatternArguments> createPatternTests() {
+        String patternId = pattern.pattern_id;
         return Stream.of(
             // Add a new stop to the end.
             new PatternArguments(
-                new PatternLocationDTO[]{
-                    new PatternLocationDTO(pattern.pattern_id, locationOne.location_id, 0, 10, 10)
+                new PatternLocationDTO[] {
+                    new PatternLocationDTO(patternId, locationOne.location_id, 0, 10, 10)
                 },
-                new PatternStopDTO[]{
-                    new PatternStopDTO(pattern.pattern_id, stopOne.stop_id, 1, 10, 1),
-                    new PatternStopDTO(pattern.pattern_id, stopTwo.stop_id, 2, 10, 1)
+                new PatternStopDTO[] {
+                    new PatternStopDTO(patternId, stopOne.stop_id, 1, 10, 1),
+                    new PatternStopDTO(patternId, stopTwo.stop_id, 2, 10, 1)
                 },
                 ImmutableMap.of(
                     locationOne.location_id, PatternReconciliation.PatternType.LOCATION,
                     stopOne.stop_id, PatternReconciliation.PatternType.STOP,
                     stopTwo.stop_id, PatternReconciliation.PatternType.STOP
                 ),
-                10,10,10,1
+                10, 10, 10, 1
             ),
             // Delete stop from the middle.
             new PatternArguments(
-                new PatternLocationDTO[]{
-                    new PatternLocationDTO(pattern.pattern_id, locationOne.location_id, 0, 20, 20)
+                new PatternLocationDTO[] {
+                    new PatternLocationDTO(patternId, locationOne.location_id, 0, 20, 20)
                 },
-                new PatternStopDTO[]{
-                    new PatternStopDTO(pattern.pattern_id, stopTwo.stop_id, 1, 12, 1)
+                new PatternStopDTO[] {
+                    new PatternStopDTO(patternId, stopTwo.stop_id, 1, 12, 1)
                 },
                 ImmutableMap.of(
                     locationOne.location_id, PatternReconciliation.PatternType.LOCATION,
                     stopTwo.stop_id, PatternReconciliation.PatternType.STOP
                 ),
-                20,20,12,1
+                20, 20, 12, 1
             ),
             // Change the order of the location and stop.
             new PatternArguments(
-                new PatternLocationDTO[]{
-                    new PatternLocationDTO(pattern.pattern_id, locationOne.location_id, 1, 30, 30)
+                new PatternLocationDTO[] {
+                    new PatternLocationDTO(patternId, locationOne.location_id, 1, 30, 30)
                 },
-                new PatternStopDTO[]{
-                    new PatternStopDTO(pattern.pattern_id, stopTwo.stop_id, 0, 11, 1)
+                new PatternStopDTO[] {
+                    new PatternStopDTO(patternId, stopTwo.stop_id, 0, 11, 1)
                 },
                 ImmutableMap.of(
                     stopTwo.stop_id, PatternReconciliation.PatternType.STOP,
                     locationOne.location_id, PatternReconciliation.PatternType.LOCATION
                 ),
-                30,30,11,1
+                30, 30, 11, 1
             ),
             // Add a new location between the location and stop.
             new PatternArguments(
-                new PatternLocationDTO[]{
-                    new PatternLocationDTO(pattern.pattern_id, locationOne.location_id, 2, 40, 40),
-                    new PatternLocationDTO(pattern.pattern_id, locationTwo.location_id, 1, 40, 40)
+                new PatternLocationDTO[] {
+                    new PatternLocationDTO(patternId, locationOne.location_id, 2, 40, 40),
+                    new PatternLocationDTO(patternId, locationTwo.location_id, 1, 40, 40)
                 },
-                new PatternStopDTO[]{
-                    new PatternStopDTO(pattern.pattern_id, stopTwo.stop_id, 0, 12, 5)
+                new PatternStopDTO[] {
+                    new PatternStopDTO(patternId, stopTwo.stop_id, 0, 12, 5)
                 },
                 ImmutableMap.of(
                     stopTwo.stop_id, PatternReconciliation.PatternType.STOP,
                     locationTwo.location_id, PatternReconciliation.PatternType.LOCATION,
                     locationOne.location_id, PatternReconciliation.PatternType.LOCATION
                 ),
-                40,40,12,5
+                40, 40, 12, 5
             ),
             // Add a new stop at the end.
             new PatternArguments(
-                new PatternLocationDTO[]{
-                    new PatternLocationDTO(pattern.pattern_id, locationOne.location_id, 2, 50, 50),
-                    new PatternLocationDTO(pattern.pattern_id, locationTwo.location_id, 1, 50, 50)
+                new PatternLocationDTO[] {
+                    new PatternLocationDTO(patternId, locationOne.location_id, 2, 50, 50),
+                    new PatternLocationDTO(patternId, locationTwo.location_id, 1, 50, 50)
                 },
-                new PatternStopDTO[]{
-                    new PatternStopDTO(pattern.pattern_id, stopTwo.stop_id, 0, 14, 3),
-                    new PatternStopDTO(pattern.pattern_id, stopOne.stop_id, 3, 14, 3)
+                new PatternStopDTO[] {
+                    new PatternStopDTO(patternId, stopTwo.stop_id, 0, 14, 3),
+                    new PatternStopDTO(patternId, stopOne.stop_id, 3, 14, 3)
                 },
                 ImmutableMap.of(
                     stopTwo.stop_id, PatternReconciliation.PatternType.STOP,
@@ -1161,34 +1162,34 @@ public class JDBCTableWriterTest {
                     locationOne.location_id, PatternReconciliation.PatternType.LOCATION,
                     stopOne.stop_id, PatternReconciliation.PatternType.STOP
                 ),
-                50,50,14,3
+                50, 50, 14, 3
             ),
             // Delete the first location.
             new PatternArguments(
-                new PatternLocationDTO[]{
-                    new PatternLocationDTO(pattern.pattern_id, locationOne.location_id, 1, 60, 60)
+                new PatternLocationDTO[] {
+                    new PatternLocationDTO(patternId, locationOne.location_id, 1, 60, 60)
                 },
-                new PatternStopDTO[]{
-                    new PatternStopDTO(pattern.pattern_id, stopTwo.stop_id, 0, 23, 1),
-                    new PatternStopDTO(pattern.pattern_id, stopOne.stop_id, 2, 23, 1)
+                new PatternStopDTO[] {
+                    new PatternStopDTO(patternId, stopTwo.stop_id, 0, 23, 1),
+                    new PatternStopDTO(patternId, stopOne.stop_id, 2, 23, 1)
                 },
                 ImmutableMap.of(
                     stopTwo.stop_id, PatternReconciliation.PatternType.STOP,
                     locationOne.location_id, PatternReconciliation.PatternType.LOCATION,
                     stopOne.stop_id, PatternReconciliation.PatternType.STOP
                 ),
-                60,60,23,1
+                60, 60, 23, 1
             ),
             // Add a stop and location to the end.
             new PatternArguments(
-                new PatternLocationDTO[]{
-                    new PatternLocationDTO(pattern.pattern_id, locationOne.location_id, 1, 70, 70),
-                    new PatternLocationDTO(pattern.pattern_id, locationThree.location_id, 3, 70, 70)
+                new PatternLocationDTO[] {
+                    new PatternLocationDTO(patternId, locationOne.location_id, 1, 70, 70),
+                    new PatternLocationDTO(patternId, locationThree.location_id, 3, 70, 70)
                 },
-                new PatternStopDTO[]{
-                    new PatternStopDTO(pattern.pattern_id, stopTwo.stop_id, 0, 13, 6),
-                    new PatternStopDTO(pattern.pattern_id, stopOne.stop_id, 2, 13, 6),
-                    new PatternStopDTO(pattern.pattern_id, stopThree.stop_id, 4, 13, 6)
+                new PatternStopDTO[] {
+                    new PatternStopDTO(patternId, stopTwo.stop_id, 0, 13, 6),
+                    new PatternStopDTO(patternId, stopOne.stop_id, 2, 13, 6),
+                    new PatternStopDTO(patternId, stopThree.stop_id, 4, 13, 6)
                 },
                 ImmutableMap.of(
                     stopTwo.stop_id, PatternReconciliation.PatternType.STOP,
@@ -1197,7 +1198,7 @@ public class JDBCTableWriterTest {
                     locationThree.location_id, PatternReconciliation.PatternType.LOCATION,
                     stopThree.stop_id, PatternReconciliation.PatternType.STOP
                 ),
-                70,70,13,6
+                70, 70, 13, 6
             )
         );
     }
@@ -1257,7 +1258,7 @@ public class JDBCTableWriterTest {
             stopSequence
         );
         LOG.info(sql);
-        ResultSet stopTimesResultSet = connection.prepareStatement(sql).executeQuery();
+        ResultSet stopTimesResultSet = connection.createStatement().executeQuery(sql);
         if (!stopTimesResultSet.isBeforeFirst()) {
             throw new SQLException(
                 String.format(


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR addresses the issue of pattern stops and pattern locations being processed in series as part of the parent/child update in JDBCTableWriter. Pattern reconciliation (as well as pattern frequencies update) require all pattern stops and pattern locations to correctly update the stop times table.

JDBCTableWriter has been updated to collate pattern stops/locations and then triggers pattern reconciliation after the parent/child updates have been carried out. If pattern frequencies require updating this is triggered after pattern reconciliation so the cummulative travel times are correctly applied according to the updated pattern sequence.

This also addresses this bug: https://github.com/conveyal/gtfs-lib/pull/335#issuecomment-1079137841. See changes in src/main/java/com/conveyal/gtfs/model/StopTime.java.
