### PR TITLE
Cascade delete on route and pattern delete

### DIFF
--- a/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
+++ b/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
@@ -1633,11 +1633,11 @@ public class JdbcTableWriter implements TableWriter {
     }
 
     /**
-     * Execute the provided sql and return the number of rows updated.
+     * Execute the provided sql and return the number of rows effected.
      */
     private int executeStatement(String sql) throws SQLException {
         try (Statement statement = connection.createStatement()) {
-            LOG.info("{}", statement);
+            LOG.info("{}", sql);
             return statement.executeUpdate(sql);
         }
     }

--- a/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
+++ b/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
@@ -1534,15 +1534,15 @@ public class JdbcTableWriter implements TableWriter {
      * To prevent orphaned descendants, delete them before joining references are deleted. For the relationship
      * route -> pattern -> pattern stop, delete pattern stop before deleting the joining pattern.
      */
-    private void deleteDescendants(String parentTableName, String keyValue) throws SQLException {
+    private void deleteDescendants(String parentTableName, String routeOrPatternId) throws SQLException {
         // Delete child references before joining trips and patterns are deleted.
         String keyColumn = (parentTableName.equals(Table.PATTERNS.name)) ? "pattern_id" : "route_id";
-        deleteStopTimesAndFrequencies(keyValue, keyColumn, parentTableName);
-        deleteShapes(keyValue, keyColumn, parentTableName);
+        deleteStopTimesAndFrequencies(routeOrPatternId, keyColumn, parentTableName);
+        deleteShapes(routeOrPatternId, keyColumn, parentTableName);
 
         if (parentTableName.equals(Table.ROUTES.name)) {
             // Delete pattern stops before joining patterns are deleted.
-            deletePatternStops(keyValue);
+            deletePatternStops(routeOrPatternId);
             // TODO: Flex delete pattern locations.
         }
     }
@@ -1633,7 +1633,7 @@ public class JdbcTableWriter implements TableWriter {
     }
 
     /**
-     * Execute the provided sql and return the number of rows effected.
+     * Execute the provided sql and return the number of rows updated.
      */
     private int executeStatement(String sql) throws SQLException {
         try (Statement statement = connection.createStatement()) {

--- a/src/test/java/com/conveyal/gtfs/loader/JDBCTableWriterTest.java
+++ b/src/test/java/com/conveyal/gtfs/loader/JDBCTableWriterTest.java
@@ -560,7 +560,7 @@ public class JDBCTableWriterTest {
         // Make sure saved data matches expected data.
         assertThat(pattern.route_id, equalTo(routeId));
 
-        TripDTO tripInput = constructTimetableTrip(pattern.pattern_id, pattern.route_id, startTime, 60);
+        TripDTO tripInput = constructFrequencyTrip(pattern.pattern_id, pattern.route_id, startTime);
         JdbcTableWriter createTripWriter = createTestTableWriter(Table.TRIPS);
         String createdTripOutput = createTripWriter.create(mapper.writeValueAsString(tripInput), true);
         TripDTO createdTrip = mapper.readValue(createdTripOutput, TripDTO.class);
@@ -608,6 +608,15 @@ public class JDBCTableWriterTest {
                 String.format("%s.%s", testNamespace, Table.SHAPES.name),
                 String.format("%s.%s", testNamespace, Table.PATTERNS.name),
                 pattern.pattern_id
+            ));
+
+        // Check that frequency records for trip do not exist in DB
+        assertThatSqlQueryYieldsZeroRows(
+            String.format(
+                "select * from %s.%s where trip_id='%s'",
+                testNamespace,
+                Table.FREQUENCIES.name,
+                createdTrip.trip_id
             ));
     }
 
@@ -926,7 +935,7 @@ public class JDBCTableWriterTest {
         input.pattern_id = patternId;
         input.route_id = routeId;
         input.name = name;
-        input.use_frequency = 0;
+        input.use_frequency = 1;
         input.shape_id = sharedShapeId;
         input.shapes = new ShapePointDTO[]{
             new ShapePointDTO(2, 0.0, sharedShapeId, firstStopLat, firstStopLon, 0),

--- a/src/test/java/com/conveyal/gtfs/loader/JDBCTableWriterTest.java
+++ b/src/test/java/com/conveyal/gtfs/loader/JDBCTableWriterTest.java
@@ -600,6 +600,15 @@ public class JDBCTableWriterTest {
                 Table.PATTERN_STOP.name,
                 pattern.pattern_id
             ));
+
+        // Check that shape records for pattern do not exist in DB
+        assertThatSqlQueryYieldsZeroRows(
+            String.format(
+                "select * from %s s, %s p where s.shape_id = p.shape_id and p.pattern_id = '%s'",
+                String.format("%s.%s", testNamespace, Table.SHAPES.name),
+                String.format("%s.%s", testNamespace, Table.PATTERNS.name),
+                pattern.pattern_id
+            ));
     }
 
     /**
@@ -918,7 +927,7 @@ public class JDBCTableWriterTest {
         input.route_id = routeId;
         input.name = name;
         input.use_frequency = 0;
-        input.shape_id = "1";
+        input.shape_id = sharedShapeId;
         input.shapes = new ShapePointDTO[]{
             new ShapePointDTO(2, 0.0, sharedShapeId, firstStopLat, firstStopLon, 0),
             new ShapePointDTO(2, 150.0, sharedShapeId, lastStopLat, lastStopLon, 1)

--- a/src/test/java/com/conveyal/gtfs/loader/JDBCTableWriterTest.java
+++ b/src/test/java/com/conveyal/gtfs/loader/JDBCTableWriterTest.java
@@ -591,6 +591,15 @@ public class JDBCTableWriterTest {
                 Table.STOP_TIMES.name,
                 createdTrip.trip_id
             ));
+
+        // Check that pattern_stops records for pattern do not exist in DB
+        assertThatSqlQueryYieldsZeroRows(
+            String.format(
+                "select * from %s.%s where pattern_id='%s'",
+                testNamespace,
+                Table.PATTERN_STOP.name,
+                pattern.pattern_id
+            ));
     }
 
     /**
@@ -901,7 +910,8 @@ public class JDBCTableWriterTest {
     /**
      * Creates a pattern by first creating a route and then a pattern for that route.
      */
-    private static PatternDTO createSimplePattern(String routeId, String patternId, String name) throws InvalidNamespaceException, SQLException, IOException {
+    private static PatternDTO createSimplePattern(String routeId, String patternId, String name)
+        throws InvalidNamespaceException, SQLException, IOException {
         // Create new pattern for route
         PatternDTO input = new PatternDTO();
         input.pattern_id = patternId;
@@ -910,7 +920,10 @@ public class JDBCTableWriterTest {
         input.use_frequency = 0;
         input.shape_id = null;
         input.shapes = new ShapePointDTO[]{};
-        input.pattern_stops = new PatternStopDTO[]{};
+        input.pattern_stops = new PatternStopDTO[]{
+            new PatternStopDTO(patternId, firstStopId, 0),
+            new PatternStopDTO(patternId, lastStopId, 1)
+        };
         // Write the pattern to the database
         JdbcTableWriter createPatternWriter = createTestTableWriter(Table.PATTERNS);
         String output = createPatternWriter.create(mapper.writeValueAsString(input), true);

--- a/src/test/java/com/conveyal/gtfs/loader/JDBCTableWriterTest.java
+++ b/src/test/java/com/conveyal/gtfs/loader/JDBCTableWriterTest.java
@@ -918,8 +918,11 @@ public class JDBCTableWriterTest {
         input.route_id = routeId;
         input.name = name;
         input.use_frequency = 0;
-        input.shape_id = null;
-        input.shapes = new ShapePointDTO[]{};
+        input.shape_id = "1";
+        input.shapes = new ShapePointDTO[]{
+            new ShapePointDTO(2, 0.0, sharedShapeId, firstStopLat, firstStopLon, 0),
+            new ShapePointDTO(2, 150.0, sharedShapeId, lastStopLat, lastStopLon, 1)
+        };
         input.pattern_stops = new PatternStopDTO[]{
             new PatternStopDTO(patternId, firstStopId, 0),
             new PatternStopDTO(patternId, lastStopId, 1)


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

To address these Jira tickets:

1. https://ibisolutions.atlassian.net/browse/DT-71
2. https://ibisolutions.atlassian.net/browse/DT-72 

A refactor to delete pattern stops, stop times, frequencies and shapes when a route or pattern is deleted. DT only has one level deep deletes, so prior to this update only patterns and trips were deleted leaving orphaned pattern stops, stop times, frequencies and shapes (second level references).

To test locally run the following maven command on GTFS-Lib: `mvn install -Dmaven.test.skip=true` and then update the datatools-server dependency to:

```
        <dependency>
            <groupId>com.conveyal</groupId>
            <artifactId>gtfs-lib</artifactId>
            <version>7.0.2</version>
            <!-- Exclusions added in order to silence SLF4J warnings about multiple bindings:
                http://www.slf4j.org/codes.html#multiple_bindings
            -->
            <exclusions>
                <exclusion>
                    <groupId>org.slf4j</groupId>
                    <artifactId>slf4j-simple</artifactId>
                </exclusion>
            </exclusions>
        </dependency>

```
### NOTE!

It looks like this will require an update to the UI as well in the form of a refresh. With an update in place to delete shapes if a route or pattern is deleted the route alignments remain until the map is refreshed. E.g. Click on “Back to Feed” and then “Edit feed” will show the updated route alignments.


