### PR TITLE
fix(TripPatternKey): Resolve omitted pickup or drop-off fields to defaults

### DIFF
--- a/src/main/java/com/conveyal/gtfs/TripPatternKey.java
+++ b/src/main/java/com/conveyal/gtfs/TripPatternKey.java
@@ -9,6 +9,8 @@ import gnu.trove.list.array.TIntArrayList;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.conveyal.gtfs.model.Entity.INT_MISSING;
+
 /**
  * Used as a map key when grouping trips by stop pattern. Note that this includes the routeId, so the same sequence of
  * stops on two different routes makes two different patterns.
@@ -34,8 +36,8 @@ public class TripPatternKey {
 
     public void addStopTime (StopTime st) {
         stops.add(st.stop_id);
-        pickupTypes.add(st.pickup_type);
-        dropoffTypes.add(st.drop_off_type);
+        pickupTypes.add(resolvePickupOrDropOffType(st.pickup_type));
+        dropoffTypes.add(resolvePickupOrDropOffType(st.drop_off_type));
         // Note, the items listed below are not used in the equality check.
         arrivalTimes.add(st.arrival_time);
         departureTimes.add(st.departure_time);
@@ -43,6 +45,16 @@ public class TripPatternKey {
         shapeDistances.add(st.shape_dist_traveled);
         continuous_pickup.add(st.continuous_pickup);
         continuous_drop_off.add(st.continuous_drop_off);
+    }
+
+    /**
+     * Resolves omitted (INT_MISSING) values for pickup and drop-off types to the default value (0 - regular)
+     * for the purposes of determining whether entries in stop_times correspond to the same trip pattern(s).
+     * @param pickupOrDropOffType the pickup or drop-off type to resolve.
+     * @return 0 if pickupOrDropOffType is 0 or INT_MISSING, else pickupOrDropOffType.
+     */
+    private int resolvePickupOrDropOffType(int pickupOrDropOffType) {
+        return pickupOrDropOffType == INT_MISSING ? 0 : pickupOrDropOffType;
     }
 
     @Override

--- a/src/test/java/com/conveyal/gtfs/GTFSTest.java
+++ b/src/test/java/com/conveyal/gtfs/GTFSTest.java
@@ -41,12 +41,12 @@ import java.util.Iterator;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
-import static com.conveyal.gtfs.graphql.GTFSGraphQLTest.testDBName;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
 /**
@@ -163,6 +163,55 @@ public class GTFSTest {
             "Integration test passes",
             runIntegrationTestOnFolder("fake-agency-bad-calendar-date", nullValue(), expectations, errorExpectations),
             equalTo(true)
+        );
+    }
+
+    /**
+     * Tests that a GTFS feed with blank (unspecified) values for pickup and dropoff types in stop_times.txt
+     * is loaded with the blank values resolved, so that the patterns are counted correctly.
+     */
+    @Test
+    public void canLoadFeedAndResolveUnsetPickupDropOffValues () {
+        PersistenceExpectation persistenceExpectation1 = makePickupDropOffPersistenceExpectation(1);
+        PersistenceExpectation persistenceExpectation2 = makePickupDropOffPersistenceExpectation(2);
+
+        PersistenceExpectation[] expectations1 = PersistenceExpectation.list(
+            persistenceExpectation1
+        );
+        PersistenceExpectation[] expectations2 = PersistenceExpectation.list(
+            persistenceExpectation1,
+            // There should be only one pattern, so the record below should not be created after loading the test feed.
+            persistenceExpectation2
+        );
+        ErrorExpectation[] errorExpectations = ErrorExpectation.list(
+            new ErrorExpectation(NewGTFSErrorType.FEED_TRAVEL_TIMES_ROUNDED)
+        );
+
+        // The first pattern should be added to the editor patterns table.
+        assertThat(
+            "There should be one pattern in the patterns table after resolving blank pickup/dropoff values in stop_times.",
+            runIntegrationTestOnFolder("fake-ferry-blank-pickups", nullValue(), expectations1, errorExpectations),
+            equalTo(true)
+        );
+
+        // The second pattern should not be added to the editor patterns table (it should throw an exception if found).
+        assertThrows(
+            AssertionError.class,
+            () -> runIntegrationTestOnFolder("fake-ferry-blank-pickups", nullValue(), expectations2, errorExpectations),
+            "There should be *only* one pattern in the patterns table after resolving blank pickup/dropoff values."
+        );
+    }
+
+    private PersistenceExpectation makePickupDropOffPersistenceExpectation(int index) {
+         return new PersistenceExpectation(
+            "patterns",
+            new RecordExpectation[]{
+                new RecordExpectation("pattern_id", String.valueOf(index)),
+                new RecordExpectation("route_id", "Tib-AIF"),
+                new RecordExpectation("direction_id", 1),
+                new RecordExpectation("shape_id", "y7d8"),
+            },
+            true
         );
     }
 

--- a/src/test/java/com/conveyal/gtfs/GTFSTest.java
+++ b/src/test/java/com/conveyal/gtfs/GTFSTest.java
@@ -194,7 +194,8 @@ public class GTFSTest {
             equalTo(true)
         );
 
-        // The second pattern should not be added to the editor patterns table (it should throw an exception if found).
+        // The second pattern should not be added to the editor patterns table
+        // (there *should* be an assertion error about the second record from expectations2 not found).
         assertThrows(
             AssertionError.class,
             () -> runIntegrationTestOnFolder("fake-ferry-blank-pickups", nullValue(), expectations2, errorExpectations),

--- a/src/test/java/com/conveyal/gtfs/TripPatternKeyTest.java
+++ b/src/test/java/com/conveyal/gtfs/TripPatternKeyTest.java
@@ -1,0 +1,54 @@
+package com.conveyal.gtfs;
+
+import com.conveyal.gtfs.model.StopTime;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static com.conveyal.gtfs.model.Entity.INT_MISSING;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TripPatternKeyTest {
+    /**
+     * A StopTime instance with pickup/drop-off field set to the default value (0 - regular) and another instance
+     * with the same field omitted should result to two TripPatternKey objects that are deemed equal.
+     */
+    @ParameterizedTest
+    @MethodSource("createStopTimesForPickupAndDropOffChecks")
+    void shouldConsiderSetAndUnsetPickupDropOffs(StopTime testStopTime, String omittedField) {
+        // Note: pickup_type and drop_off_type are initialized to zero by default.
+        StopTime commonStopTime = new StopTime();
+        commonStopTime.stop_id = "stop1";
+
+        StopTime referenceStopTime = new StopTime();
+        referenceStopTime.stop_id = "stop2";
+        testStopTime.stop_id = "stop2";
+
+        String routeId = "test-route";
+
+        TripPatternKey referenceKey = new TripPatternKey(routeId);
+        referenceKey.addStopTime(commonStopTime);
+        referenceKey.addStopTime(referenceStopTime);
+
+        TripPatternKey otherKey = new TripPatternKey(routeId);
+        otherKey.addStopTime(commonStopTime);
+        otherKey.addStopTime(testStopTime);
+
+        assertEquals(referenceKey, otherKey, "TripPatternKey did not correctly interpret missing value for" + omittedField);
+    }
+
+    private static Stream<Arguments> createStopTimesForPickupAndDropOffChecks() {
+        StopTime st1 = new StopTime();
+        st1.pickup_type = INT_MISSING;
+
+        StopTime st2 = new StopTime();
+        st2.drop_off_type = INT_MISSING;
+
+        return Stream.of(
+            Arguments.of(st1, "pickup_type"),
+            Arguments.of(st2, "dropoff_type")
+        );
+    }
+}

--- a/src/test/resources/fake-ferry-blank-pickups/agency.txt
+++ b/src/test/resources/fake-ferry-blank-pickups/agency.txt
@@ -1,0 +1,2 @@
+agency_id,agency_name,agency_url,agency_timezone,agency_lang,agency_phone,agency_branding_url,agency_fare_url,agency_email
+AF,A Ferry,http://www.example.com,America/Los_Angeles,,,,,

--- a/src/test/resources/fake-ferry-blank-pickups/attributions.txt
+++ b/src/test/resources/fake-ferry-blank-pickups/attributions.txt
@@ -1,0 +1,1 @@
+attribution_id,agency_id,route_id,trip_id,organization_name,is_producer,is_operator,is_authority,attribution_url,attribution_email,attribution_phone

--- a/src/test/resources/fake-ferry-blank-pickups/calendar.txt
+++ b/src/test/resources/fake-ferry-blank-pickups/calendar.txt
@@ -1,0 +1,3 @@
+service_id,monday,tuesday,wednesday,thursday,friday,saturday,sunday,start_date,end_date
+01,0,0,0,0,0,1,1,20220401,20220531
+03,1,1,1,1,1,0,0,20220401,20220531

--- a/src/test/resources/fake-ferry-blank-pickups/calendar_dates.txt
+++ b/src/test/resources/fake-ferry-blank-pickups/calendar_dates.txt
@@ -1,0 +1,1 @@
+service_id,date,exception_type

--- a/src/test/resources/fake-ferry-blank-pickups/fare_attributes.txt
+++ b/src/test/resources/fake-ferry-blank-pickups/fare_attributes.txt
@@ -1,0 +1,5 @@
+fare_id,price,currency_type,payment_method,transfers,agency_id,transfer_duration
+A1,15.00,USD,1,0,AF,
+A2,14.00,USD,1,0,AF,
+A3,13.00,USD,1,0,AF,
+A4,5.00,USD,1,0,AF,

--- a/src/test/resources/fake-ferry-blank-pickups/fare_rules.txt
+++ b/src/test/resources/fake-ferry-blank-pickups/fare_rules.txt
@@ -1,0 +1,1 @@
+fare_id,route_id,origin_id,destination_id,contains_id

--- a/src/test/resources/fake-ferry-blank-pickups/feed_info.txt
+++ b/src/test/resources/fake-ferry-blank-pickups/feed_info.txt
@@ -1,0 +1,2 @@
+feed_publisher_name,feed_id,feed_publisher_url,feed_lang,feed_start_date,feed_end_date,feed_version,default_lang,feed_contact_email,feed_contact_url
+Angel Island Ferry,,https://angelislandferry.com/,en,,,,,,

--- a/src/test/resources/fake-ferry-blank-pickups/frequencies.txt
+++ b/src/test/resources/fake-ferry-blank-pickups/frequencies.txt
@@ -1,0 +1,1 @@
+trip_id,start_time,end_time,headway_secs,exact_times

--- a/src/test/resources/fake-ferry-blank-pickups/routes.txt
+++ b/src/test/resources/fake-ferry-blank-pickups/routes.txt
@@ -1,0 +1,2 @@
+route_id,agency_id,route_short_name,route_long_name,route_desc,route_type,route_url,route_branding_url,route_color,route_text_color,route_sort_order,continuous_pickup,continuous_drop_off
+Tib-AIF,AF,FY-A,A Ferry,,4,,,7ab8e4,000000,,,

--- a/src/test/resources/fake-ferry-blank-pickups/shapes.txt
+++ b/src/test/resources/fake-ferry-blank-pickups/shapes.txt
@@ -1,0 +1,3 @@
+shape_id,shape_pt_sequence,shape_pt_lat,shape_pt_lon,shape_dist_traveled
+y7d8,0,37.872572,-122.455719,0
+y7d8,1,37.868307,-122.435089,1871.92069611793681

--- a/src/test/resources/fake-ferry-blank-pickups/stop_times.txt
+++ b/src/test/resources/fake-ferry-blank-pickups/stop_times.txt
@@ -1,0 +1,5 @@
+trip_id,stop_sequence,stop_id,arrival_time,departure_time,stop_headsign,pickup_type,drop_off_type,continuous_pickup,continuous_drop_off,shape_dist_traveled,timepoint
+1003,0,TBF,15:00:00,15:00:00,,0,0,1,1,0,
+1003,1,AIF,15:15:00,15:15:00,,0,0,1,1,1871.92069611793681,
+1005,0,TBF,10:00:00,10:00:00,,,,1,1,0,0
+1005,1,AIF,10:15:00,10:15:00,,,,1,1,1871.92069611793681,0

--- a/src/test/resources/fake-ferry-blank-pickups/stops.txt
+++ b/src/test/resources/fake-ferry-blank-pickups/stops.txt
@@ -1,0 +1,3 @@
+stop_id,stop_code,stop_name,stop_desc,stop_lat,stop_lon,zone_id,stop_url,location_type,parent_station,stop_timezone,wheelchair_boarding,platform_code
+AIF,,AIF Terminal,,37.868307,-122.435089,,,0,,,1,
+TBF,,TBF Terminal,,37.872572,-122.455719,,,0,,,1,

--- a/src/test/resources/fake-ferry-blank-pickups/transfers.txt
+++ b/src/test/resources/fake-ferry-blank-pickups/transfers.txt
@@ -1,0 +1,1 @@
+from_stop_id,to_stop_id,transfer_type,min_transfer_time

--- a/src/test/resources/fake-ferry-blank-pickups/translations.txt
+++ b/src/test/resources/fake-ferry-blank-pickups/translations.txt
@@ -1,0 +1,1 @@
+table_name,field_name,language,translation,record_id,record_sub_id,field_value

--- a/src/test/resources/fake-ferry-blank-pickups/trips.txt
+++ b/src/test/resources/fake-ferry-blank-pickups/trips.txt
@@ -1,0 +1,3 @@
+trip_id,route_id,service_id,trip_headsign,trip_short_name,direction_id,block_id,shape_id,wheelchair_accessible,bikes_allowed
+1003,Tib-AIF,03,Angel Island Ferry Terminal,,1,100,y7d8,,
+1005,Tib-AIF,01,Angel Island Ferry Terminal,,1,100,y7d8,,


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Fix #351 by adding logic to `TripPatternKey` to resolve omitted `pickup_type` and `drop_off_type` fields in `stop_times` entries to the default values per the GTFS spec.
