### PR TITLE
Multiple Location Groups

### DIFF
--- a/src/main/java/com/conveyal/gtfs/GTFSFeed.java
+++ b/src/main/java/com/conveyal/gtfs/GTFSFeed.java
@@ -233,7 +233,10 @@ public class GTFSFeed implements Cloneable, Closeable {
             new StopTime.Writer(this).writeTable(zip);
 
             if (!this.bookingRules.isEmpty()) new BookingRule.Writer(this).writeTable(zip);
-            if (!this.locationGroups.isEmpty()) new LocationGroup.Writer(this).writeTable(zip);
+            if (!this.locationGroups.isEmpty()) {
+                // export location groups
+                JdbcGtfsExporter.writeLocationGroupsToFile(zip, new ArrayList<>(locationGroups.values()));
+            }
             if (!this.locations.isEmpty()) {
                 // export locations
                 JdbcGtfsExporter.writeLocationsToFile(

--- a/src/main/java/com/conveyal/gtfs/error/NewGTFSErrorType.java
+++ b/src/main/java/com/conveyal/gtfs/error/NewGTFSErrorType.java
@@ -59,6 +59,7 @@ public enum NewGTFSErrorType {
     INTEGER_FORMAT(Priority.MEDIUM, "Incorrect integer format."),
     LANGUAGE_FORMAT(Priority.LOW, "Language should be specified with a valid BCP47 tag."),
     LOCATION_UNUSED(Priority.MEDIUM, "This location is not referenced by any trips."),
+    LOCATION_GROUP_PARSING(Priority.HIGH, "Unable to parse the location_groups.txt file. Make sure the file conforms to the GTFS Flex standard."),
     LOCATION_GROUP_UNUSED(Priority.MEDIUM, "This location group is not referenced by any trips."),
     MISSING_ARRIVAL_OR_DEPARTURE(Priority.MEDIUM, "First and last stop times are required to have both an arrival and departure time."),
     MISSING_COLUMN(Priority.MEDIUM, "A required column was missing from a table."),

--- a/src/main/java/com/conveyal/gtfs/loader/Table.java
+++ b/src/main/java/com/conveyal/gtfs/loader/Table.java
@@ -1,6 +1,7 @@
 package com.conveyal.gtfs.loader;
 
 import com.conveyal.gtfs.error.NewGTFSError;
+import com.conveyal.gtfs.error.NewGTFSErrorType;
 import com.conveyal.gtfs.error.SQLErrorStorage;
 import com.conveyal.gtfs.loader.conditions.AgencyHasMultipleRowsCheck;
 import com.conveyal.gtfs.loader.conditions.ConditionalRequirement;
@@ -65,6 +66,7 @@ import java.util.zip.ZipFile;
 
 import static com.conveyal.gtfs.error.NewGTFSErrorType.DUPLICATE_HEADER;
 import static com.conveyal.gtfs.error.NewGTFSErrorType.GEO_JSON_PARSING;
+import static com.conveyal.gtfs.error.NewGTFSErrorType.LOCATION_GROUP_PARSING;
 import static com.conveyal.gtfs.error.NewGTFSErrorType.TABLE_IN_SUBDIRECTORY;
 import static com.conveyal.gtfs.loader.JdbcGtfsLoader.sanitize;
 import static com.conveyal.gtfs.loader.Requirement.EDITOR;
@@ -86,6 +88,7 @@ public class Table {
     private static final Logger LOG = LoggerFactory.getLogger(Table.class);
 
     public static final String LOCATION_GEO_JSON_FILE_NAME = "locations.geojson";
+    public static final String LOCATION_GROUPS_FILE_NAME = Table.LOCATION_GROUPS.name + ".txt";
 
     public final String name;
 
@@ -737,11 +740,15 @@ public class Table {
         }
         if (entry == null) return null;
         try {
-            List<String> geoJsonErrors = new ArrayList<>();
-            CsvReader csvReader = getCsvReader(tableFileName, name, zipFile, entry, geoJsonErrors);
-            if (!geoJsonErrors.isEmpty() && sqlErrorStorage != null) {
-                geoJsonErrors.forEach(error ->
-                    sqlErrorStorage.storeError(NewGTFSError.forFeed(GEO_JSON_PARSING, error))
+            List<String> errors = new ArrayList<>();
+            CsvReader csvReader = getCsvReader(tableFileName, name, zipFile, entry, errors);
+            if (!errors.isEmpty() && sqlErrorStorage != null) {
+                // Errors will only be populated if parsing locations.geojson or location_groups.txt.
+                NewGTFSErrorType errorType = (tableFileName.equals(LOCATION_GEO_JSON_FILE_NAME))
+                    ? GEO_JSON_PARSING
+                    : LOCATION_GROUP_PARSING;
+                errors.forEach(error ->
+                    sqlErrorStorage.storeError(NewGTFSError.forFeed(errorType, error))
                 );
             }
             // Don't skip empty records. This is set to true by default on CsvReader. We want to check for empty records
@@ -770,6 +777,8 @@ public class Table {
         CsvReader csvReader;
         if (tableFileName.equals(LOCATION_GEO_JSON_FILE_NAME)) {
             csvReader = GeoJsonUtil.getCsvReaderFromGeoJson(name, zipFile, entry, errors);
+        } else if (tableFileName.equals(LOCATION_GROUPS_FILE_NAME)) {
+            csvReader = LocationGroup.getCsvReader(zipFile, entry, errors);
         } else {
             InputStream zipInputStream = zipFile.getInputStream(entry);
             // Skip any byte order mark that may be present. Files must be UTF-8,

--- a/src/main/java/com/conveyal/gtfs/loader/Table.java
+++ b/src/main/java/com/conveyal/gtfs/loader/Table.java
@@ -88,7 +88,7 @@ public class Table {
     private static final Logger LOG = LoggerFactory.getLogger(Table.class);
 
     public static final String LOCATION_GEO_JSON_FILE_NAME = "locations.geojson";
-    public static final String LOCATION_GROUPS_FILE_NAME = Table.LOCATION_GROUPS.name + ".txt";
+    public static final String LOCATION_GROUPS_FILE_NAME = "location_groups.txt";
 
     public final String name;
 

--- a/src/test/resources/fake-agency-with-flex/location_groups.txt
+++ b/src/test/resources/fake-agency-with-flex/location_groups.txt
@@ -2,3 +2,5 @@ location_group_id,location_id,location_group_name
 1,123,"Location group referencing a stop"
 2,area-999,"Location group referencing an invalid location"
 3,area_1469-1,"Location group referencing a location"
+4,123,"Multi location group"
+4,area_1469-1,"Multi location group"

--- a/src/test/resources/snapshots/com/conveyal/gtfs/graphql/GTFSGraphQLTest/canFetchLocationGroups-0.json
+++ b/src/test/resources/snapshots/com/conveyal/gtfs/graphql/GTFSGraphQLTest/canFetchLocationGroups-0.json
@@ -17,6 +17,11 @@
         "location_group_id" : "3",
         "location_group_name" : "Location group referencing a location",
         "location_id" : "area_1469-1"
+      }, {
+        "id" : 5,
+        "location_group_id" : "4",
+        "location_group_name" : "Multi location group",
+        "location_id" : "123,area_1469-1"
       } ]
     }
   }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR covers loading, exporting and validating multiple location groups. Multi location groups are defined as two or more location groups with the same id. These location groups on loading are combined into a single record/row with an array of location id values. On export, the reverse takes place expanding multi location groups in to single rows to conform with the GTFS Flex spec. A special case has been added to validate references where more than one location id has been defined i.e. it loops over all location ids and checks references for each.
