### PR TITLE
Flex trip pattern key update

### DIFF
--- a/src/main/java/com/conveyal/gtfs/TripPatternKey.java
+++ b/src/main/java/com/conveyal/gtfs/TripPatternKey.java
@@ -8,6 +8,7 @@ import gnu.trove.list.array.TIntArrayList;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import static com.conveyal.gtfs.model.Entity.INT_MISSING;
 
@@ -22,6 +23,10 @@ public class TripPatternKey {
     public List<String> stops = new ArrayList<>();
     public TIntList pickupTypes = new TIntArrayList();
     public TIntList dropoffTypes = new TIntArrayList();
+    // Flex additions included in equality check.
+    public TIntList start_pickup_dropoff_window = new TIntArrayList();
+    public TIntList end_pickup_dropoff_window = new TIntArrayList();
+
     // Note, the lists below are not used in the equality check.
     public TIntList arrivalTimes = new TIntArrayList();
     public TIntList departureTimes = new TIntArrayList();
@@ -33,10 +38,6 @@ public class TripPatternKey {
     // Flex additions
     public List<String> pickup_booking_rule_id = new ArrayList<>();
     public List<String> drop_off_booking_rule_id = new ArrayList<>();
-
-    // Additional GTFS Flex location groups and locations fields
-    public TIntList start_pickup_dropoff_window = new TIntArrayList();
-    public TIntList end_pickup_dropoff_window = new TIntArrayList();
     public TDoubleList mean_duration_factor = new TDoubleArrayList();
     public TDoubleList mean_duration_offset = new TDoubleArrayList();
     public TDoubleList safe_duration_factor = new TDoubleArrayList();
@@ -85,10 +86,12 @@ public class TripPatternKey {
 
         TripPatternKey that = (TripPatternKey) o;
 
-        if (dropoffTypes != null ? !dropoffTypes.equals(that.dropoffTypes) : that.dropoffTypes != null) return false;
-        if (pickupTypes != null ? !pickupTypes.equals(that.pickupTypes) : that.pickupTypes != null) return false;
-        if (routeId != null ? !routeId.equals(that.routeId) : that.routeId != null) return false;
-        if (stops != null ? !stops.equals(that.stops) : that.stops != null) return false;
+        if (!Objects.equals(dropoffTypes, that.dropoffTypes)) return false;
+        if (!Objects.equals(pickupTypes, that.pickupTypes)) return false;
+        if (!Objects.equals(routeId, that.routeId)) return false;
+        if (!Objects.equals(stops, that.stops)) return false;
+        if (!Objects.equals(start_pickup_dropoff_window, that.start_pickup_dropoff_window)) return false;
+        if (!Objects.equals(end_pickup_dropoff_window, that.end_pickup_dropoff_window)) return false;
 
         return true;
     }
@@ -99,6 +102,8 @@ public class TripPatternKey {
         result = 31 * result + (stops != null ? stops.hashCode() : 0);
         result = 31 * result + (pickupTypes != null ? pickupTypes.hashCode() : 0);
         result = 31 * result + (dropoffTypes != null ? dropoffTypes.hashCode() : 0);
+        result = 31 * result + (start_pickup_dropoff_window != null ? start_pickup_dropoff_window.hashCode() : 0);
+        result = 31 * result + (end_pickup_dropoff_window != null ? end_pickup_dropoff_window.hashCode() : 0);
         return result;
     }
 

--- a/src/main/java/com/conveyal/gtfs/TripPatternKey.java
+++ b/src/main/java/com/conveyal/gtfs/TripPatternKey.java
@@ -98,13 +98,6 @@ public class TripPatternKey {
 
     @Override
     public int hashCode() {
-        int result = routeId != null ? routeId.hashCode() : 0;
-        result = 31 * result + (stops != null ? stops.hashCode() : 0);
-        result = 31 * result + (pickupTypes != null ? pickupTypes.hashCode() : 0);
-        result = 31 * result + (dropoffTypes != null ? dropoffTypes.hashCode() : 0);
-        result = 31 * result + (start_pickup_dropoff_window != null ? start_pickup_dropoff_window.hashCode() : 0);
-        result = 31 * result + (end_pickup_dropoff_window != null ? end_pickup_dropoff_window.hashCode() : 0);
-        return result;
+        return Objects.hash(routeId, stops, pickupTypes, dropoffTypes, start_pickup_dropoff_window, end_pickup_dropoff_window);
     }
-
 }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR updates the trip pattern key equality check so that flex start/end pickup and drop off windows are also considered. This then creates additional patterns based on these values. Prior to this update trips were being grouped under the same, first, pattern which meant trips would have the wrong start/end pickup and drop off windows.
