### PR TITLE
Avoid importing duplicate locations

### DIFF
--- a/src/main/java/com/conveyal/gtfs/util/GeoJsonUtil.java
+++ b/src/main/java/com/conveyal/gtfs/util/GeoJsonUtil.java
@@ -101,6 +101,13 @@ public class GeoJsonUtil {
     }
 
     /**
+     *   Check for features without IDs, with empty geometry or duplicate IDs (this happens more than you think)
+     */
+    private static boolean isValidLocation(String locationId, String geometryType, Set<String> seenLocationIds) {
+        return (locationId == null || geometryType == null || !seenLocationIds.add(locationId)) ? false : true;
+    }
+
+    /**
      * Extract from a list of features, the items which are common to all features.
      */
     private static List<Location> unpackLocations(
@@ -108,14 +115,13 @@ public class GeoJsonUtil {
         List<String> errors
     ) {
         ArrayList<Location> locations = new ArrayList<>();
-        Set<String> seenLocationIds = new HashSet<String>();
+        Set<String> seenLocationIds = new HashSet<>();
         for (Feature feature : featureCollection.getFeatures()) {
             String geometryType = getGeometryType(feature.getGeometryType().getName(), errors);
             Location location = new Location();
             String locationId = feature.getId();
 
-            // Skip empty geometry and skip duplicate IDs (this happens more than you think)
-            if (locationId == null || geometryType == null || !seenLocationIds.add(locationId)) continue;
+            if (!isValidLocation(locationId, geometryType, seenLocationIds)) continue;
 
             location.location_id = locationId;
             location.geometry_type = geometryType;
@@ -198,13 +204,12 @@ public class GeoJsonUtil {
         List<String> errors
     ) {
         ArrayList<LocationShape> locationShapes = new ArrayList<>();
-        Set<String> seenLocationIds = new HashSet<String>();
+        Set<String> seenLocationIds = new HashSet<>();
         for (Feature feature : featureCollection.getFeatures()) {
             Geometry geometry = feature.getFeature().getGeometry();
             String geometryType = getGeometryType(geometry.getGeometryType().getName(), errors);
             String locationId = feature.getId();
-            // Skip features without IDs, empty geometry and skip duplicate IDs (this happens more than you think)
-            if (locationId == null || geometryType == null || !seenLocationIds.add(locationId)) continue;
+            if (!isValidLocation(locationId, geometryType, seenLocationIds)) continue;
             switch (geometryType) {
                 case GEOMETRY_TYPE_POLYLINE:
                     LineString lineString = (LineString) geometry;

--- a/src/main/java/com/conveyal/gtfs/util/GeoJsonUtil.java
+++ b/src/main/java/com/conveyal/gtfs/util/GeoJsonUtil.java
@@ -115,7 +115,7 @@ public class GeoJsonUtil {
             String locationId = feature.getId();
 
             // Skip empty geometry and skip duplicate IDs (this happens more than you think)
-            if (geometryType == null || !seenLocationIds.add(locationId)) continue;
+            if (locationId == null || geometryType == null || !seenLocationIds.add(locationId)) continue;
 
             location.location_id = locationId;
             location.geometry_type = geometryType;
@@ -202,16 +202,16 @@ public class GeoJsonUtil {
         for (Feature feature : featureCollection.getFeatures()) {
             Geometry geometry = feature.getFeature().getGeometry();
             String geometryType = getGeometryType(geometry.getGeometryType().getName(), errors);
-
-            // Skip empty geometry and skip duplicate IDs (this happens more than you think)
-            if (geometryType == null || !seenLocationIds.add(feature.getId())) continue;
+            String locationId = feature.getId();
+            // Skip features without IDs, empty geometry and skip duplicate IDs (this happens more than you think)
+            if (locationId == null || geometryType == null || !seenLocationIds.add(locationId)) continue;
             switch (geometryType) {
                 case GEOMETRY_TYPE_POLYLINE:
                     LineString lineString = (LineString) geometry;
                     for (Point point : lineString.getPoints()) {
                         locationShapes.add(
                             // Because we're only supporting a single linestring right now, use location_id as the geometry_id too
-                            buildLocationShape(feature.getId(), feature.getId(), point.getY(), point.getX())
+                            buildLocationShape(locationId, locationId, point.getY(), point.getX())
                         );
                     }
                     break;

--- a/src/main/java/com/conveyal/gtfs/util/GeoJsonUtil.java
+++ b/src/main/java/com/conveyal/gtfs/util/GeoJsonUtil.java
@@ -24,7 +24,12 @@ import java.io.StringReader;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -103,15 +108,15 @@ public class GeoJsonUtil {
         List<String> errors
     ) {
         ArrayList<Location> locations = new ArrayList<>();
-        Set<String> uniqueLocationIds = new HashSet<String>();
+        Set<String> seenLocationIds = new HashSet<String>();
         for (Feature feature : featureCollection.getFeatures()) {
             String geometryType = getGeometryType(feature.getGeometryType().getName(), errors);
-            if (geometryType == null) continue;
             Location location = new Location();
             String locationId = feature.getId();
 
-            // Skip duplicate IDs (this happens more than you think)
-            if (!uniqueLocationIds.add(locationId)) continue;
+            // Skip empty geometry and skip duplicate IDs (this happens more than you think)
+            if (geometryType == null || !seenLocationIds.add(locationId)) continue;
+
             location.location_id = locationId;
             location.geometry_type = geometryType;
             extractPropertyValues(location, feature.getProperties(), errors);
@@ -193,13 +198,13 @@ public class GeoJsonUtil {
         List<String> errors
     ) {
         ArrayList<LocationShape> locationShapes = new ArrayList<>();
-        Set<String> uniqueLocationIds = new HashSet<String>();
+        Set<String> seenLocationIds = new HashSet<String>();
         for (Feature feature : featureCollection.getFeatures()) {
             Geometry geometry = feature.getFeature().getGeometry();
             String geometryType = getGeometryType(geometry.getGeometryType().getName(), errors);
-            if (geometryType == null) continue;
-            // Skip duplicate IDs (this happens more than you think)
-            if (!uniqueLocationIds.add(feature.getId())) continue;
+
+            // Skip empty geometry and skip duplicate IDs (this happens more than you think)
+            if (geometryType == null || !seenLocationIds.add(feature.getId())) continue;
             switch (geometryType) {
                 case GEOMETRY_TYPE_POLYLINE:
                     LineString lineString = (LineString) geometry;


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Avoid unpacking locations and locationShapes for duplicate locations in locations.geojson (same id). This happens a lot more than you'd think and causes UI issues. 
