### PR TITLE
Add deletion of calendar dates for exceptions

### DIFF
--- a/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
+++ b/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
@@ -18,8 +18,6 @@ import gnu.trove.list.array.TIntArrayList;
 import gnu.trove.set.TIntSet;
 import gnu.trove.set.hash.TIntHashSet;
 import org.apache.commons.dbutils.DbUtils;
-import org.apache.commons.lang3.ArrayUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1466,7 +1464,7 @@ public class JdbcTableWriter implements TableWriter {
     }
 
     /**
-     * Parse a list field in the schedule exceptions table (dates, added_service, or removed_service) into a list of string.
+     * Parse a list field in the schedule exceptions table (dates, added_service, or removed_service) into an array of strings.
      * List fields take the form {ServiceId1, ServiceId2, ServiceId3, ...}
      */
     private String[] parseExceptionListField(int id, String namespace, Table table, String type) throws SQLException {
@@ -1554,11 +1552,12 @@ public class JdbcTableWriter implements TableWriter {
             // Update/delete foreign references that have match the key value.
             String refTableName = String.join(".", namespace, referencingTable.name);
             int result;
-            // Custom logic for calendar dates because schedule_exceptions does not reference calendar dates right now.
             if (table.name.equals("schedule_exceptions") && referencingTable.name.equals("calendar_dates")) {
+                // Custom logic for calendar dates because schedule_exceptions does not reference calendar dates right now.
                 result = deleteCalendarDatesForException(id, namespace, table, refTableName);
                 LOG.info("Deleted {} entries in calendar dates associated with schedule exception {}", result, id);
-            } else { // General deletion
+            } else {
+                // General deletion
                 for (Field field : referencingTable.editorFields()) {
                     if (field.isForeignReference() && field.referenceTable.name.equals(table.name)) {
                         // Get statement to update or delete entities that reference the key value.

--- a/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
+++ b/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
@@ -1491,12 +1491,12 @@ public class JdbcTableWriter implements TableWriter {
         String[] serviceIds = parseExceptionListField(id, namespace, table, "service");
         String[] dates = parseExceptionListField(id, namespace, table, "dates");
         int resultCount = 0;
+        String sql = String.format("delete from %s where service_id = ? and date = ?", refTableName);
+        PreparedStatement updateStatement = connection.prepareStatement(sql);
 
         // Schedule exceptions map to many different calendar dates (one for each date / service ID combination)
         for (String date : dates) {
             for (String serviceId : serviceIds) {
-                String sql =String.format("delete from %s where service_id = ? and date = ?", refTableName);
-                PreparedStatement updateStatement = connection.prepareStatement(sql);
                 updateStatement.setString(1, serviceId);
                 updateStatement.setString(2, date);
                 LOG.info(updateStatement.toString());

--- a/src/test/java/com/conveyal/gtfs/dto/CalendarDateDTO.java
+++ b/src/test/java/com/conveyal/gtfs/dto/CalendarDateDTO.java
@@ -1,0 +1,8 @@
+package com.conveyal.gtfs.dto;
+
+public class CalendarDateDTO {
+    public Integer id;
+    public String service_id;
+    public String date;
+    public Integer exception_type;
+}

--- a/src/test/java/com/conveyal/gtfs/loader/JDBCTableWriterTest.java
+++ b/src/test/java/com/conveyal/gtfs/loader/JDBCTableWriterTest.java
@@ -430,8 +430,8 @@ public class JDBCTableWriterTest {
     public void canCreateAndDeleteCalendarDates() throws IOException, SQLException, InvalidNamespaceException {
         String firstServiceId = "REMOVED";
         String secondServiceId = "ADDED";
-        String[] allServiceIds = new String[]{firstServiceId, secondServiceId};
-        String[] holidayDates = new String[]{"20190812", "20190813", "20190814"};
+        String[] allServiceIds = new String[] {firstServiceId, secondServiceId};
+        String[] holidayDates = new String[] {"20190812", "20190813", "20190814"};
 
         final Table scheduleExceptionTable = Table.SCHEDULE_EXCEPTIONS;
         final Table calendarDatesTable = Table.CALENDAR_DATES;
@@ -441,8 +441,8 @@ public class JDBCTableWriterTest {
         ScheduleExceptionDTO exceptionInput = new ScheduleExceptionDTO();
         exceptionInput.name = "Incredible multi day holiday";
         exceptionInput.exemplar = 9; // Add, swap, or remove type
-        exceptionInput.removed_service = new String[]{firstServiceId};
-        exceptionInput.added_service = new String[]{secondServiceId};
+        exceptionInput.removed_service = new String[] {firstServiceId};
+        exceptionInput.added_service = new String[] {secondServiceId};
         exceptionInput.dates = holidayDates;
 
         // Save the schedule exception
@@ -1124,7 +1124,7 @@ public class JDBCTableWriterTest {
     /**
      * Create and store a simple calendar date that modifies service on one day.
      */
-    private static CalendarDateDTO createAndStoreCalendarDate(String serviceId, String date, int exceptionType)  throws IOException, SQLException, InvalidNamespaceException {
+    private static CalendarDateDTO createAndStoreCalendarDate(String serviceId, String date, int exceptionType) throws IOException, SQLException, InvalidNamespaceException {
         JdbcTableWriter createCalendarDateWriter = new JdbcTableWriter(Table.CALENDAR_DATES, testDataSource, testNamespace);
 
         CalendarDateDTO calendarDate = createCalendarDate(serviceId, date, exceptionType);


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing


### Description

Currently calendar dates are not deleted when an exception is removed. This can cause bugs when trying to delete calendars which have references in calendar_dates. Effectively these become inaccessible from the UI to delete and free up the calendar for deletion. 