### PR TITLE
Fix pattern ID uses in stop deletion link

### DIFF
--- a/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
+++ b/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
@@ -1576,7 +1576,7 @@ public class JdbcTableWriter implements TableWriter {
                                     connection.rollback();
                                     if (entityClass.getSimpleName().equals("Stop")) {
                                         String patternStopLookup = String.format(
-                                            "select distinct ps.pattern_id, r.id " +
+                                            "select distinct p.id, r.id " +
                                             "from %s.pattern_stops ps " +
                                             "inner join " +
                                             "%s.patterns p " +


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Recent changes returned the pattern_id rather than the id in the `patterns` table (they are often the same) in the link for a stop deletion. This PR resolves that issue. 