### PR TITLE
Allow commas in service IDs

### DIFF
--- a/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
+++ b/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
@@ -427,7 +427,10 @@ public class JdbcTableWriter implements TableWriter {
                         // Array field type expects comma-delimited values.
                         List<String> values = new ArrayList<>();
                         for (JsonNode node : value) {
-                            values.add(node.asText());
+                            String nodeText = node.asText();
+                            // Surround text value in quotes to preserve any internal commas
+                            if (field instanceof StringListField) nodeText = "\"" + nodeText + "\"";
+                            values.add(nodeText);
                         }
                         field.setParameter(preparedStatement, index, String.join(",", values));
                     } else {

--- a/src/main/java/com/conveyal/gtfs/loader/StringListField.java
+++ b/src/main/java/com/conveyal/gtfs/loader/StringListField.java
@@ -9,6 +9,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLType;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -35,10 +36,10 @@ public class StringListField extends Field {
     public Set<NewGTFSError> setParameter(PreparedStatement preparedStatement, int oneBasedIndex, String string) {
         try {
             // Only split on commas following an escaped quotation mark, as this indicates a new item in the list.
-            String[] stringList = string.split("(?<=\"),");
+            List<String> stringList = Arrays.asList(string.split("(?<=\"),"));
             // Clean the string list of any escaped quotations which are required to preserve any internal commas.
-            stringList = Arrays.stream(stringList).map(s -> s.replace("\"", "")).toArray(String[]::new);
-            Array array = preparedStatement.getConnection().createArrayOf("text", stringList);
+            stringList.replaceAll(s -> s.replace("\"", ""));
+            Array array = preparedStatement.getConnection().createArrayOf("text", stringList.toArray(new String[0]));
             preparedStatement.setArray(oneBasedIndex, array);
             return Collections.EMPTY_SET;
         } catch (Exception e) {

--- a/src/main/java/com/conveyal/gtfs/loader/StringListField.java
+++ b/src/main/java/com/conveyal/gtfs/loader/StringListField.java
@@ -7,6 +7,7 @@ import java.sql.Array;
 import java.sql.JDBCType;
 import java.sql.PreparedStatement;
 import java.sql.SQLType;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;
 
@@ -34,7 +35,10 @@ public class StringListField extends Field {
     public Set<NewGTFSError> setParameter(PreparedStatement preparedStatement, int oneBasedIndex, String string) {
         // FIXME
         try {
-            Array array = preparedStatement.getConnection().createArrayOf("text", string.split(","));
+            String[] stringList = string.split("(?<=\"),");
+            // Clean the string list of any escaped quotations which are required to preserve any internal commas
+            stringList = Arrays.stream(stringList).map(s -> s.replace("\"", "")).toArray(String[]::new);
+            Array array = preparedStatement.getConnection().createArrayOf("text", stringList);
             preparedStatement.setArray(oneBasedIndex, array);
             return Collections.EMPTY_SET;
         } catch (Exception e) {

--- a/src/main/java/com/conveyal/gtfs/loader/StringListField.java
+++ b/src/main/java/com/conveyal/gtfs/loader/StringListField.java
@@ -33,10 +33,10 @@ public class StringListField extends Field {
 
     @Override
     public Set<NewGTFSError> setParameter(PreparedStatement preparedStatement, int oneBasedIndex, String string) {
-        // FIXME
         try {
+            // Only split on commas following an escaped quotation mark, as this indicates a new item in the list.
             String[] stringList = string.split("(?<=\"),");
-            // Clean the string list of any escaped quotations which are required to preserve any internal commas
+            // Clean the string list of any escaped quotations which are required to preserve any internal commas.
             stringList = Arrays.stream(stringList).map(s -> s.replace("\"", "")).toArray(String[]::new);
             Array array = preparedStatement.getConnection().createArrayOf("text", stringList);
             preparedStatement.setArray(oneBasedIndex, array);


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Previously, including commas in a Service ID caused bugs when saving an exception. This PR preserves internal commas in StringList values.
