### PR TITLE
fix: add support for externally defined `newGTFSErrorType`

### DIFF
--- a/src/main/java/com/conveyal/gtfs/error/NewGTFSError.java
+++ b/src/main/java/com/conveyal/gtfs/error/NewGTFSError.java
@@ -23,7 +23,7 @@ public class NewGTFSError {
     public Class<? extends Entity> entityType;
 
     /** The kind of error encountered. */
-    public final NewGTFSErrorType errorType;
+    public final NewGTFSErrorInterface errorType;
 
     /** Key-value pairs providing additional information about this error. */
     public Map<String, String> errorInfo = new HashMap<>();
@@ -70,13 +70,13 @@ public class NewGTFSError {
      * @param entityType should be supplied for a table, may be null if the error affects a whole feed.
      * @param errorType must always be supplied.
      */
-    private NewGTFSError (Class<? extends Entity> entityType, NewGTFSErrorType errorType) {
+    private NewGTFSError (Class<? extends Entity> entityType, NewGTFSErrorInterface errorType) {
         this.entityType = entityType;
         this.errorType = errorType;
     }
 
     // Factory Builder for cases where an entity has not yet been constructed, but we know the line number.
-    public static NewGTFSError forLine (Table table, int lineNumber, NewGTFSErrorType errorType, String badValue) {
+    public static NewGTFSError forLine (Table table, int lineNumber, NewGTFSErrorInterface errorType, String badValue) {
         NewGTFSError error = new NewGTFSError(table.getEntityClass(), errorType);
         error.lineNumber = lineNumber;
         error.badValue = badValue;
@@ -84,7 +84,7 @@ public class NewGTFSError {
     }
 
     // Factory Builder for cases where an entity has not yet been constructed, but we know the line number.
-    public static NewGTFSError forLine(LineContext lineContext, NewGTFSErrorType errorType, String badValue) {
+    public static NewGTFSError forLine(LineContext lineContext, NewGTFSErrorInterface errorType, String badValue) {
         NewGTFSError error = new NewGTFSError(lineContext.table.getEntityClass(), errorType);
         error.lineNumber = lineContext.lineNumber;
         error.badValue = badValue;
@@ -92,7 +92,7 @@ public class NewGTFSError {
     }
 
     // Factory Builder for cases where the entity has already been decoded and an error is discovered during validation
-    public static NewGTFSError forEntity(Entity entity, NewGTFSErrorType errorType) {
+    public static NewGTFSError forEntity(Entity entity, NewGTFSErrorInterface errorType) {
         NewGTFSError error = new NewGTFSError(entity.getClass(), errorType);
         error.lineNumber = entity.id;
         error.entityId = entity.getId();
@@ -101,12 +101,12 @@ public class NewGTFSError {
     }
 
     // Factory Builder
-    public static NewGTFSError forTable (Table table, NewGTFSErrorType errorType) {
+    public static NewGTFSError forTable (Table table, NewGTFSErrorInterface errorType) {
         return new NewGTFSError(table.getEntityClass(), errorType);
     }
 
     // Factory Builder for feed-wide error
-    public static NewGTFSError forFeed (NewGTFSErrorType errorType, String badValue) {
+    public static NewGTFSError forFeed (NewGTFSErrorInterface errorType, String badValue) {
         return new NewGTFSError(null, errorType).setBadValue(badValue);
     }
 

--- a/src/main/java/com/conveyal/gtfs/error/NewGTFSErrorInterface.java
+++ b/src/main/java/com/conveyal/gtfs/error/NewGTFSErrorInterface.java
@@ -1,0 +1,13 @@
+package com.conveyal.gtfs.error;
+
+import com.conveyal.gtfs.validator.model.Priority;
+
+/**
+ * Interface the enum implements, allowing for externally defined error types
+ */
+public interface NewGTFSErrorInterface {
+    Priority priority = null;
+    String englishMessage = null;
+
+    String name();
+}

--- a/src/main/java/com/conveyal/gtfs/error/NewGTFSErrorType.java
+++ b/src/main/java/com/conveyal/gtfs/error/NewGTFSErrorType.java
@@ -6,7 +6,7 @@ import com.conveyal.gtfs.validator.model.Priority;
  * This enum defines the GTFS error types that can be encountered when validating GTFS table data. Each error type has a
  * severity level and related error message.
  */
-public enum NewGTFSErrorType {
+public enum NewGTFSErrorType implements NewGTFSErrorInterface {
     // Standard errors.
     AGENCY_ID_REQUIRED_FOR_MULTI_AGENCY_FEEDS(Priority.HIGH, "For GTFS feeds with more than one agency, agency_id is required."),
     BOOLEAN_FORMAT(Priority.MEDIUM, "A GTFS boolean field must contain the value 1 or 0."),

--- a/src/main/java/com/conveyal/gtfs/validator/Validator.java
+++ b/src/main/java/com/conveyal/gtfs/validator/Validator.java
@@ -1,6 +1,7 @@
 package com.conveyal.gtfs.validator;
 
 import com.conveyal.gtfs.error.NewGTFSError;
+import com.conveyal.gtfs.error.NewGTFSErrorInterface;
 import com.conveyal.gtfs.error.NewGTFSErrorType;
 import com.conveyal.gtfs.error.SQLErrorStorage;
 import com.conveyal.gtfs.loader.Feed;
@@ -33,7 +34,7 @@ public abstract class Validator {
     /**
      * Store an error that affects a single line of a single table. Wraps the underlying error factory method.
      */
-    public void registerError(Entity entity, NewGTFSErrorType errorType) {
+    public void registerError(Entity entity, NewGTFSErrorInterface errorType) {
         errorStorage.storeError(NewGTFSError.forEntity(entity, errorType));
     }
 
@@ -49,7 +50,7 @@ public abstract class Validator {
      * collection of errors need to be temporarily held before storing in batch (e.g., waiting to store travel time zero
      * errors before it is determined that the entire feed uses travel times rounded to the minute).
      */
-    NewGTFSError createUnregisteredError (Entity entity, NewGTFSErrorType errorType) {
+    NewGTFSError createUnregisteredError (Entity entity, NewGTFSErrorInterface errorType) {
         return NewGTFSError.forEntity(entity, errorType);
     }
 
@@ -65,7 +66,7 @@ public abstract class Validator {
      * Store an error that affects a single line of a single table.
      * Add a bad value to it.
      */
-    public void registerError(Entity entity, NewGTFSErrorType errorType, Object badValue) {
+    public void registerError(Entity entity, NewGTFSErrorInterface errorType, Object badValue) {
         errorStorage.storeError(NewGTFSError.forEntity(entity, errorType).setBadValue(badValue.toString()));
     }
 


### PR DESCRIPTION
This is facilitated by having `newGTFSErrorType` implement a new interface. This interface can be implemented by external code as well, allowing the internal error methods to make use of error types gtfs-lib does not know about.