### PR TITLE
fix: new shared stops error types

### DIFF
--- a/src/main/java/com/conveyal/gtfs/error/NewGTFSErrorType.java
+++ b/src/main/java/com/conveyal/gtfs/error/NewGTFSErrorType.java
@@ -86,9 +86,9 @@ public enum NewGTFSErrorType {
     FIELD_VALUE_TOO_LONG(Priority.MEDIUM, "Field value has too many characters."),
 
     // Shared Stops-specifc errors.
-    MULTIPLE_SHARED_STOPS_GROUPS(Priority.HIGH, "GTFS entity belongs to more than one shared-stop group."),
-    SHARED_STOP_GROUP_MUTLIPLE_PRIMARY_STOPS(Priority.HIGH, "Shared-stop group has multiple primary stops."),
-    SHARED_STOP_GROUP_ENTITY_DOES_NOT_EXIST(Priority.MEDIUM, "Shared-stop group entity does not exist."),
+    MULTIPLE_SHARED_STOPS_GROUPS(Priority.HIGH, "A GTFS stop belongs to more than one shared-stop group."),
+    SHARED_STOP_GROUP_MUTLIPLE_PRIMARY_STOPS(Priority.HIGH, "A Shared-stop group has multiple primary stops."),
+    SHARED_STOP_GROUP_ENTITY_DOES_NOT_EXIST(Priority.MEDIUM, "The stop referenced by a shared-stop does not exist."),
 
     // Unknown errors.
     OTHER(Priority.LOW, "Other errors.");

--- a/src/main/java/com/conveyal/gtfs/error/NewGTFSErrorType.java
+++ b/src/main/java/com/conveyal/gtfs/error/NewGTFSErrorType.java
@@ -85,6 +85,11 @@ public enum NewGTFSErrorType {
     // MTC-specific errors.
     FIELD_VALUE_TOO_LONG(Priority.MEDIUM, "Field value has too many characters."),
 
+    // Shared Stops-specifc errors.
+    MULTIPLE_SHARED_STOPS_GROUPS(Priority.HIGH, "GTFS entity belongs to more than one shared-stop group."),
+    SHARED_STOP_GROUP_MUTLIPLE_PRIMARY_STOPS(Priority.HIGH, "Shared-stop group has multiple primary stops."),
+    SHARED_STOP_GROUP_ENTITY_DOES_NOT_EXIST(Priority.MEDIUM, "Shared-stop group entity does not exist."),
+
     // Unknown errors.
     OTHER(Priority.LOW, "Other errors.");
 


### PR DESCRIPTION
### Checklist

- [ ] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [ ] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [ ] The description lists all applicable issues this PR seeks to resolve
- [ ] The description lists any configuration setting(s) that differ from the default settings
- [ ] All tests and CI builds passing
- [ ] The description lists all relevant PRs included in this release _(remove this if not merging to master)_
- [ ] Code coverage does not significantly worsen (ideally it improves) _(remove this if not merging to master)_

### Description

Unfortunately the superior approach from #390 did not work, and so we must now instead add shared stops errors to `gtfs-lib` explicitly.