### PR TITLE
Add route GTFS shortnames to pattern stop error message

### DIFF
--- a/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
+++ b/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
@@ -1599,7 +1599,7 @@ public class JdbcTableWriter implements TableWriter {
                                             ResultSet resultSet = patternStopSelectStatement.getResultSet();
                                             while (resultSet.next()) {
                                                 patternAndRouteIds.add(
-                                                    "{" + resultSet.getString(1) + "-" + resultSet.getString(2) + resultSet.getString(3) + "}"
+                                                    "{" + resultSet.getString(1) + "-" + resultSet.getString(2) + "-" + resultSet.getString(3) + "}"
                                                 );
                                             }
                                         }

--- a/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
+++ b/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
@@ -1484,7 +1484,8 @@ public class JdbcTableWriter implements TableWriter {
     }
 
     private String getResultSetString(int column, ResultSet resultSet) throws java.sql.SQLException {
-        return resultSet.getString(column) == null ? "" : resultSet.getString(resultSet.getString(1) == null ? "" : resultSet.getString(1));
+        String resultSetString = resultSet.getString(column);
+        return resultSetString == null ? "" : resultSetString;
     }
 
     /**

--- a/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
+++ b/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
@@ -1579,7 +1579,7 @@ public class JdbcTableWriter implements TableWriter {
                                     connection.rollback();
                                     if (entityClass.getSimpleName().equals("Stop")) {
                                         String patternStopLookup = String.format(
-                                            "select distinct p.id, r.id, r.route_short_name " +
+                                            "select distinct p.id, r.id, r.route_short_name, r.route_id " +
                                             "from %s.pattern_stops ps " +
                                             "inner join " +
                                             "%s.patterns p " +
@@ -1599,7 +1599,7 @@ public class JdbcTableWriter implements TableWriter {
                                             ResultSet resultSet = patternStopSelectStatement.getResultSet();
                                             while (resultSet.next()) {
                                                 patternAndRouteIds.add(
-                                                    "{" + resultSet.getString(1) + "-" + resultSet.getString(2) + "-" + resultSet.getString(3) + "}"
+                                                    "{" + resultSet.getString(1) + "-" + resultSet.getString(2) + "-" + resultSet.getString(3) + "-" + resultSet.getString(3) + "}"
                                                 );
                                             }
                                         }

--- a/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
+++ b/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
@@ -1604,7 +1604,12 @@ public class JdbcTableWriter implements TableWriter {
                                             ResultSet resultSet = patternStopSelectStatement.getResultSet();
                                             while (resultSet.next()) {
                                                 patternAndRouteIds.add(
-                                                    "{" + getResultSetString(1, resultSet) + "-" + getResultSetString(2, resultSet) + "-" + getResultSetString(3, resultSet)+ "-" + getResultSetString(4, resultSet) + "}"
+                                                    String.format("{%s-%s-%s-%s}",
+                                                        getResultSetString(1, resultSet),
+                                                        getResultSetString(2, resultSet),
+                                                        getResultSetString(3, resultSet),
+                                                        getResultSetString(4, resultSet)
+                                                    )
                                                 );
                                             }
                                         }

--- a/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
+++ b/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
@@ -1579,7 +1579,7 @@ public class JdbcTableWriter implements TableWriter {
                                     connection.rollback();
                                     if (entityClass.getSimpleName().equals("Stop")) {
                                         String patternStopLookup = String.format(
-                                            "select distinct p.id, r.id, r.route_id " +
+                                            "select distinct p.id, r.id, r.route_short_name " +
                                             "from %s.pattern_stops ps " +
                                             "inner join " +
                                             "%s.patterns p " +

--- a/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
+++ b/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
@@ -1579,7 +1579,7 @@ public class JdbcTableWriter implements TableWriter {
                                     connection.rollback();
                                     if (entityClass.getSimpleName().equals("Stop")) {
                                         String patternStopLookup = String.format(
-                                            "select distinct p.id, r.id " +
+                                            "select distinct p.id, r.id, r.route_id " +
                                             "from %s.pattern_stops ps " +
                                             "inner join " +
                                             "%s.patterns p " +
@@ -1599,7 +1599,7 @@ public class JdbcTableWriter implements TableWriter {
                                             ResultSet resultSet = patternStopSelectStatement.getResultSet();
                                             while (resultSet.next()) {
                                                 patternAndRouteIds.add(
-                                                    "{" + resultSet.getString(1) + "-" + resultSet.getString(2) + "}"
+                                                    "{" + resultSet.getString(1) + "-" + resultSet.getString(2) + resultSet.getString(3) + "}"
                                                 );
                                             }
                                         }

--- a/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
+++ b/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
@@ -1483,6 +1483,10 @@ public class JdbcTableWriter implements TableWriter {
         return parsedString.replaceAll("[{}]", "").split("[,]", 0);
     }
 
+    private String getResultSetString(int column, ResultSet resultSet) throws java.sql.SQLException {
+        return resultSet.getString(column) == null ? "" : resultSet.getString(resultSet.getString(1) == null ? "" : resultSet.getString(1));
+    }
+
     /**
      * Delete all entries in calendar dates associated with a schedule exception.
      */
@@ -1599,7 +1603,7 @@ public class JdbcTableWriter implements TableWriter {
                                             ResultSet resultSet = patternStopSelectStatement.getResultSet();
                                             while (resultSet.next()) {
                                                 patternAndRouteIds.add(
-                                                    "{" + resultSet.getString(1) + "-" + resultSet.getString(2) + "-" + resultSet.getString(3) + "-" + resultSet.getString(3) + "}"
+                                                    "{" + getResultSetString(1, resultSet) + "-" + getResultSetString(2, resultSet) + "-" + getResultSetString(3, resultSet)+ "-" + getResultSetString(4, resultSet) + "}"
                                                 );
                                             }
                                         }


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing


### Description

Previously we were displaying the internal route ID rather than the route short name which is much more useful for understanding which route is using the stop. 

Companion UI PR: https://github.com/ibi-group/datatools-ui/pull/985