### PR TITLE
Add Stop Time Interpolation

### DIFF
--- a/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
+++ b/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
@@ -257,6 +257,13 @@ public class JdbcTableWriter implements TableWriter {
     }
 
     /**
+     * Deprecated method to normalize stop times before stop time interpolation. Defaults to
+     * false for interpolation.
+     */
+    public int normalizeStopTimesForPattern(int id, int beginWithSequence) throws SQLException {
+        return normalizeStopTimesForPattern(id, beginWithSequence, false);
+    }
+    /**
      * For a given pattern id and starting stop sequence (inclusive), normalize all stop times to match the pattern
      * stops' travel times.
      *
@@ -817,6 +824,7 @@ public class JdbcTableWriter implements TableWriter {
         for (String tripId : timesForTripIds.keySet()) {
             // Initialize travel time with previous stop time value.
             int cumulativeTravelTime = timesForTripIds.get(tripId);
+            int cumulativeInterpolatedTime = cumulativeTravelTime;
             int timepointNumber = 0;
             double previousShapeDistTraveled = 0; // Used for calculating timepoint speed for interpolation
             for (PatternStop patternStop : patternStops) {
@@ -832,10 +840,19 @@ public class JdbcTableWriter implements TableWriter {
                 int dwellTime = patternStop.default_dwell_time == Entity.INT_MISSING ? 0 : patternStop.default_dwell_time;
                 int oneBasedIndex = 1;
                 // Increase travel time by current pattern stop's travel and dwell times (and set values for update).
-                cumulativeTravelTime += travelTime;
-                updateStopTimeStatement.setInt(oneBasedIndex++, cumulativeTravelTime);
-                cumulativeTravelTime += dwellTime;
-                updateStopTimeStatement.setInt(oneBasedIndex++, cumulativeTravelTime);
+                if (!isTimepoint && interpolateStopTimes) {
+                    // We don't want to increment the true cumulative travel time because that adjusts the timepoint
+                    // times later in the pattern.
+                    // TODO? We ignore dwell times in interpolation calculations right now.
+                    cumulativeInterpolatedTime += travelTime;
+                    updateStopTimeStatement.setInt(oneBasedIndex++, cumulativeInterpolatedTime);
+                    updateStopTimeStatement.setInt(oneBasedIndex++, cumulativeInterpolatedTime);
+                } else {
+                    cumulativeTravelTime += travelTime;
+                    updateStopTimeStatement.setInt(oneBasedIndex++, cumulativeTravelTime);
+                    cumulativeTravelTime += dwellTime;
+                    updateStopTimeStatement.setInt(oneBasedIndex++, cumulativeTravelTime);
+                }
                 updateStopTimeStatement.setString(oneBasedIndex++, tripId);
                 updateStopTimeStatement.setInt(oneBasedIndex++, patternStop.stop_sequence);
                 stopTimesTracker.addBatch();

--- a/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
+++ b/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
@@ -757,11 +757,6 @@ public class JdbcTableWriter implements TableWriter {
      * Updates the non-timepoint stop times between two timepoints using the speed implied  by
      * the travel time between them. Ignores any existing default_travel_time or default_dwell_time
      * entered for the non-timepoint stops.
-     * @param patternStop
-     * @param timepoints
-     * @param timepointNumber
-     * @param previousShapeDistTraveled
-     * @return
      */
     private int interpolateTimesFromTimepoints(
         PatternStop patternStop,

--- a/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
+++ b/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
@@ -764,30 +764,24 @@ public class JdbcTableWriter implements TableWriter {
      * @return
      */
     private int interpolateTimesFromTimepoints(
-            PatternStop patternStop,
-            List<PatternStop> timepoints,
-            Integer timepointNumber,
-            double previousShapeDistTraveled
+        PatternStop patternStop,
+        List<PatternStop> timepoints,
+        Integer timepointNumber,
+        double previousShapeDistTraveled
     ) {
-        if (timepointNumber == 0) {
-            throw new IllegalStateException("First pattern stop must be a timepoint to perform interpolation");
-        } else if (timepoints.size() == 1) {
-            throw new IllegalStateException("Pattern must have more than one timepoint to perform interpolation");
-        } else if (timepointNumber >= timepoints.size()) {
-            throw new IllegalStateException("Last stop must be a timepoint to perform interpolation");
+        if (timepointNumber == 0 || timepoints.size() == 1 || timepointNumber >= timepoints.size()) {
+            throw new IllegalStateException("Issue in pattern stops which prevents interpolation (e.g. less than 2 timepoints)");
         }
         PatternStop nextTimepoint = timepoints.get(timepointNumber);
         PatternStop lastTimepoint = timepoints.get(timepointNumber-1);
 
-        if (nextTimepoint == null) {
-            throw new IllegalStateException("Stop time interpolation is not possible with null timepoints.");
-        } else if (nextTimepoint.default_travel_time == Entity.INT_MISSING) {
-            throw new IllegalStateException("All timepoints must have a default travel time specified.");
-        } else if (
+        if (
+            nextTimepoint == null ||
+            nextTimepoint.default_travel_time == Entity.INT_MISSING ||
             nextTimepoint.shape_dist_traveled == Entity.DOUBLE_MISSING ||
             lastTimepoint.shape_dist_traveled == Entity.DOUBLE_MISSING
         ) {
-            throw new IllegalStateException("Shape_dist_traveled must be defined in order to perform interpolation.");
+            throw new IllegalStateException("Error with stop time interpolation: timepoint or shape_dist_traveled is null");
         }
 
         double timepointSpeed = (nextTimepoint.shape_dist_traveled - lastTimepoint.shape_dist_traveled) / nextTimepoint.default_travel_time;

--- a/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
+++ b/src/main/java/com/conveyal/gtfs/loader/JdbcTableWriter.java
@@ -785,8 +785,7 @@ public class JdbcTableWriter implements TableWriter {
         }
 
         double timepointSpeed = (nextTimepoint.shape_dist_traveled - lastTimepoint.shape_dist_traveled) / nextTimepoint.default_travel_time;
-        int travelTime = (int) Math.round((patternStop.shape_dist_traveled - previousShapeDistTraveled) / timepointSpeed);
-        return travelTime;
+        return (int) Math.round((patternStop.shape_dist_traveled - previousShapeDistTraveled) / timepointSpeed);
     }
 
     /**

--- a/src/test/java/com/conveyal/gtfs/dto/PatternStopDTO.java
+++ b/src/test/java/com/conveyal/gtfs/dto/PatternStopDTO.java
@@ -23,4 +23,12 @@ public class PatternStopDTO {
         stop_id = stopId;
         stop_sequence = stopSequence;
     }
+
+    public PatternStopDTO (String patternId, String stopId, int stopSequence, int timepointValue, double shape_dist_traveledValue) {
+        timepoint = timepointValue;
+        pattern_id = patternId;
+        stop_id = stopId;
+        stop_sequence = stopSequence;
+        shape_dist_traveled = shape_dist_traveledValue;
+    }
 }

--- a/src/test/java/com/conveyal/gtfs/loader/JDBCTableWriterTest.java
+++ b/src/test/java/com/conveyal/gtfs/loader/JDBCTableWriterTest.java
@@ -839,7 +839,7 @@ public class JDBCTableWriterTest {
     }
 
     /**
-     * Checks that {@link JdbcTableWriter#normalizeStopTimesForPattern(int, int)} can normalize stop times to a pattern's
+     * Checks that {@link JdbcTableWriter#normalizeStopTimesForPattern(int, int, boolean)} can normalize stop times to a pattern's
      * default travel times.
      */
     @Test
@@ -875,7 +875,7 @@ public class JDBCTableWriterTest {
         LOG.info("Updated pattern output: {}", updatedPatternOutput);
         // Normalize stop times.
         JdbcTableWriter updateTripWriter = createTestTableWriter(tripsTable);
-        updateTripWriter.normalizeStopTimesForPattern(pattern.id, 0);
+        updateTripWriter.normalizeStopTimesForPattern(pattern.id, 0, false);
         // Read pattern stops from database and check that the arrivals/departures have been updated.
         JDBCTableReader<StopTime> stopTimesTable = new JDBCTableReader(Table.STOP_TIMES,
                                                                        testDataSource,

--- a/src/test/java/com/conveyal/gtfs/loader/JDBCTableWriterTest.java
+++ b/src/test/java/com/conveyal/gtfs/loader/JDBCTableWriterTest.java
@@ -66,7 +66,6 @@ public class JDBCTableWriterTest {
     private static String firstStopId = "1";
     private static String secondStopId= "1.5";
     private static String lastStopId = "2";
-    private static String patternId = "123456";
     private static double firstStopLat = 34.2222;
     private static double firstStopLon = -87.333;
     private static double secondStopLat = 34.2227;
@@ -843,7 +842,7 @@ public class JDBCTableWriterTest {
             ));
     }
 
-    private static String normalizeStopsForPattern(PatternStopDTO[] patternStops, int updatedStopSequence, boolean interpolateStopTimes, int initialTravelTime, int updatedTravelTime, int startTime) throws SQLException, InvalidNamespaceException, IOException {
+    private static String normalizeStopsForPattern(PatternStopDTO[] patternStops, int updatedStopSequence, boolean interpolateStopTimes, int initialTravelTime, int updatedTravelTime, int startTime, String patternId) throws SQLException, InvalidNamespaceException, IOException {
         final Table tripsTable = Table.TRIPS;
 
         PatternDTO pattern = createRouteAndPattern(newUUID(),
@@ -881,6 +880,7 @@ public class JDBCTableWriterTest {
         int startTime = 6 * 60 * 60; // 6AM
         int initialTravelTime = 60; // seconds
         int updatedTravelTime = 600; // ten minutes
+        String patternId = "123456-interpolated";
         double[] shapeDistTraveledValues = new double[] {0.0, 300.0, 600.0};
         double timepointTravelTime = (shapeDistTraveledValues[2] - shapeDistTraveledValues[0]) / updatedTravelTime; // 1 m/s
 
@@ -894,7 +894,7 @@ public class JDBCTableWriterTest {
         patternStops[2].default_travel_time = initialTravelTime;
 
         // Pass the array of patterns to the body method with param
-        String createdTripId = normalizeStopsForPattern(patternStops, 2, true, initialTravelTime, updatedTravelTime, startTime);
+        String createdTripId = normalizeStopsForPattern(patternStops, 2, true, initialTravelTime, updatedTravelTime, startTime, patternId);
 
         // Read pattern stops from database and check that the arrivals/departures have been updated.
         JDBCTableReader<StopTime> stopTimesTable = new JDBCTableReader(Table.STOP_TIMES,
@@ -920,13 +920,14 @@ public class JDBCTableWriterTest {
         int initialTravelTime = 60; // one minute
         int startTime = 6 * 60 * 60; // 6AM
         int updatedTravelTime = 3600;
+        String patternId = "123456";
 
         PatternStopDTO[] patternStops = new PatternStopDTO[]{
             new PatternStopDTO(patternId, firstStopId, 0),
             new PatternStopDTO(patternId, lastStopId, 1)
         };
 
-        String createdTripId = normalizeStopsForPattern(patternStops, 1, false, initialTravelTime, updatedTravelTime, startTime);
+        String createdTripId = normalizeStopsForPattern(patternStops, 1, false, initialTravelTime, updatedTravelTime, startTime, patternId);
         JDBCTableReader<StopTime> stopTimesTable = new JDBCTableReader(Table.STOP_TIMES,
             testDataSource,
             testNamespace + ".",

--- a/src/test/java/com/conveyal/gtfs/loader/JDBCTableWriterTest.java
+++ b/src/test/java/com/conveyal/gtfs/loader/JDBCTableWriterTest.java
@@ -842,7 +842,15 @@ public class JDBCTableWriterTest {
             ));
     }
 
-    private static String normalizeStopsForPattern(PatternStopDTO[] patternStops, int updatedStopSequence, boolean interpolateStopTimes, int initialTravelTime, int updatedTravelTime, int startTime, String patternId) throws SQLException, InvalidNamespaceException, IOException {
+    private static String normalizeStopsForPattern(
+        PatternStopDTO[] patternStops,
+        int updatedStopSequence,
+        boolean interpolateStopTimes,
+        int initialTravelTime,
+        int updatedTravelTime,
+        int startTime,
+        String patternId
+    ) throws SQLException, InvalidNamespaceException, IOException {
         final Table tripsTable = Table.TRIPS;
 
         PatternDTO pattern = createRouteAndPattern(newUUID(),
@@ -875,7 +883,7 @@ public class JDBCTableWriterTest {
      * Checks that {@link JdbcTableWriter#normalizeStopTimesForPattern(int, int, boolean)} can interpolate stop times between timepoints.
      */
     @Test
-    public void canInterpolatePatternStopTimes() throws IOException, SQLException, InvalidNamespaceException {
+    private void canInterpolatePatternStopTimes() throws IOException, SQLException, InvalidNamespaceException {
         // Parameters are shared with canNormalizePatternStopTimes, but maintained for test flexibility.
         int startTime = 6 * 60 * 60; // 6AM
         int initialTravelTime = 60; // seconds


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This PR supports interpolating stop times based on timepoints in the `normalizeStopTimesForPattern` method. 
